### PR TITLE
Enhance user org management and header info

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -64,17 +64,23 @@ export default function App() {
   const { token, currentOrg, setCurrentOrg } = useContext(AuthContext);
   const navItems = token ? loggedInNav : loggedOutNav;
   const [orgs, setOrgs] = useState([]);
+  const [profile, setProfile] = useState(null);
 
   useEffect(() => {
     const load = async () => {
-      const res = await api.get('/organizations');
-      setOrgs(res.data.organizations);
+      const [orgRes, profRes] = await Promise.all([
+        api.get('/my/organizations'),
+        api.get('/profile')
+      ]);
+      setOrgs(orgRes.data.organizations);
+      setProfile(profRes.data);
     };
     if (token) {
       load();
     } else {
       setOrgs([]);
       setCurrentOrg('');
+      setProfile(null);
     }
   }, [token]);
 
@@ -91,6 +97,11 @@ export default function App() {
             <Typography variant="h6" noWrap component="div" sx={{ flexGrow: 1 }}>
               Auth Dashboard
             </Typography>
+            {token && profile && (
+              <Typography sx={{ mr: 2 }}>
+                {profile.firstName} {profile.lastName} ({profile.username}) | Balance: {profile.balance}
+              </Typography>
+            )}
             {token && (
               <FormControl size="small" sx={{ minWidth: 120 }}>
                 <InputLabel id="org-select-label">Org</InputLabel>

--- a/frontend/src/pages/ManageUsers.js
+++ b/frontend/src/pages/ManageUsers.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useMemo } from 'react';
-import { Box, Typography, Select, MenuItem, TextField, Button, Stack } from '@mui/material';
+import { Box, Typography, Select, MenuItem, Button, Stack } from '@mui/material';
 import { styles } from '../styles';
 import { useTable } from 'react-table';
 import api from '../api';
@@ -7,6 +7,7 @@ import api from '../api';
 export default function ManageUsers() {
   const [users, setUsers] = useState([]);
   const [roles, setRoles] = useState([]);
+  const [allOrgs, setAllOrgs] = useState([]);
   const [addOrgId, setAddOrgId] = useState('');
   const [addUserId, setAddUserId] = useState('');
   const [removeOrgId, setRemoveOrgId] = useState('');
@@ -14,12 +15,14 @@ export default function ManageUsers() {
 
   useEffect(() => {
     const load = async () => {
-      const [uRes, rRes] = await Promise.all([
+      const [uRes, rRes, oRes] = await Promise.all([
         api.get('/users'),
-        api.get('/roles')
+        api.get('/roles'),
+        api.get('/organizations/all')
       ]);
       setUsers(uRes.data);
       setRoles(rRes.data);
+      setAllOrgs(oRes.data);
     };
     load();
   }, []);
@@ -52,6 +55,11 @@ export default function ManageUsers() {
     { Header: 'First Name', accessor: 'firstName' },
     { Header: 'Last Name', accessor: 'lastName' },
     { Header: 'Balance', accessor: 'balance' },
+    {
+      Header: 'Organizations',
+      accessor: 'organizations',
+      Cell: ({ value }) => value.map(o => o.name).join(', ')
+    },
     {
       Header: 'Role',
       accessor: 'role',
@@ -114,13 +122,45 @@ export default function ManageUsers() {
       </Box>
       <Box sx={styles.actionRow}>
         <Stack direction="row" spacing={1} sx={{ mt: 2 }}>
-          <TextField size="small" label="org id" value={addOrgId} onChange={e => setAddOrgId(e.target.value)} />
-          <TextField size="small" label="user id" value={addUserId} onChange={e => setAddUserId(e.target.value)} />
+          <Select
+            size="small"
+            value={addOrgId}
+            onChange={e => setAddOrgId(e.target.value)}
+          >
+            {allOrgs.map(o => (
+              <MenuItem key={o.id} value={o.id}>{o.name}</MenuItem>
+            ))}
+          </Select>
+          <Select
+            size="small"
+            value={addUserId}
+            onChange={e => setAddUserId(e.target.value)}
+          >
+            {users.map(u => (
+              <MenuItem key={u.id} value={u.id}>{u.username}</MenuItem>
+            ))}
+          </Select>
           <Button variant="contained" onClick={addMember}>Add Member</Button>
         </Stack>
         <Stack direction="row" spacing={1} sx={{ mt: 2 }}>
-          <TextField size="small" label="org id" value={removeOrgId} onChange={e => setRemoveOrgId(e.target.value)} />
-          <TextField size="small" label="user id" value={removeUserId} onChange={e => setRemoveUserId(e.target.value)} />
+          <Select
+            size="small"
+            value={removeOrgId}
+            onChange={e => setRemoveOrgId(e.target.value)}
+          >
+            {allOrgs.map(o => (
+              <MenuItem key={o.id} value={o.id}>{o.name}</MenuItem>
+            ))}
+          </Select>
+          <Select
+            size="small"
+            value={removeUserId}
+            onChange={e => setRemoveUserId(e.target.value)}
+          >
+            {users.map(u => (
+              <MenuItem key={u.id} value={u.id}>{u.username}</MenuItem>
+            ))}
+          </Select>
           <Button variant="contained" color="error" onClick={removeMember}>Remove Member</Button>
         </Stack>
       </Box>


### PR DESCRIPTION
## Summary
- include organizations in `/profile` response and add `/my/organizations`
- expose user organizations in `/users` admin API
- display profile details and organization dropdown using new endpoint
- allow managing user organization membership with select menus

## Testing
- `npm run build`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6863072c6b7083268ad55c0e12aa664e