### PR TITLE
Implement invite listing and multi-role admin check

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -61,30 +61,26 @@ export default function App() {
     { text: 'Accept Invite', path: '/accept-invite', icon: <HowToReg /> },
     { text: 'Transfer', path: '/transfer', icon: <SwapHoriz /> },
     { text: 'Balance', path: '/balance', icon: <AccountBalanceWallet /> },
-    { text: 'Administration', path: '/admin', icon: <AdminPanelSettings /> },
     { text: 'Logout', path: '/logout', icon: <Logout /> }
   ];
 
-  const { token, currentOrg, setCurrentOrg } = useContext(AuthContext);
-  const navItems = token ? loggedInNav : loggedOutNav;
+  const { token, currentOrg, setCurrentOrg, profile } = useContext(AuthContext);
+  const adminNav = { text: 'Administration', path: '/admin', icon: <AdminPanelSettings /> };
+  const navItems = token
+    ? [...loggedInNav, ...(profile && (profile.isSuperAdmin || profile.roles?.includes('ADMIN')) ? [adminNav] : [])]
+    : loggedOutNav;
   const [orgs, setOrgs] = useState([]);
-  const [profile, setProfile] = useState(null);
 
   useEffect(() => {
     const load = async () => {
-      const [orgRes, profRes] = await Promise.all([
-        api.get('/user/organizations'),
-        api.get('/profile')
-      ]);
-      setOrgs(orgRes.data.organizations);
-      setProfile(profRes.data);
+      const res = await api.get('/user/organizations');
+      setOrgs(res.data.organizations);
     };
     if (token) {
       load();
     } else {
       setOrgs([]);
       setCurrentOrg('');
-      setProfile(null);
     }
   }, [token]);
 
@@ -119,6 +115,7 @@ export default function App() {
                   label="Org"
                   onChange={changeOrg}
                 >
+                  <MenuItem value="">All</MenuItem>
                   {orgs.map(o => (
                     <MenuItem key={o.id} value={o.id}>{o.name}</MenuItem>
                   ))}

--- a/frontend/src/AuthContext.js
+++ b/frontend/src/AuthContext.js
@@ -7,6 +7,7 @@ export function AuthProvider({ children }) {
   const [token, setTokenState] = useState(() => localStorage.getItem('token') || '');
   const [refreshToken, setRefreshTokenState] = useState(() => localStorage.getItem('refreshToken') || '');
   const [currentOrg, setCurrentOrgState] = useState(() => localStorage.getItem('currentOrg') || '');
+  const [profile, setProfileState] = useState(null);
 
   useEffect(() => {
     setAuthToken(token);
@@ -29,6 +30,20 @@ export function AuthProvider({ children }) {
   useEffect(() => {
     setTokenRefreshHandler((newToken) => setTokenState(newToken));
   }, []);
+
+  const loadProfile = async () => {
+    if (!token) { setProfileState(null); return; }
+    try {
+      const res = await api.get('/profile');
+      setProfileState(res.data);
+    } catch (e) {
+      setProfileState(null);
+    }
+  };
+
+  useEffect(() => {
+    loadProfile();
+  }, [token]);
 
 
   useEffect(() => {
@@ -65,7 +80,7 @@ export function AuthProvider({ children }) {
   };
 
   return (
-    <AuthContext.Provider value={{ token, login, logout, refreshAuth, setToken: setTokenState, currentOrg, setCurrentOrg: setCurrentOrgState }}>
+    <AuthContext.Provider value={{ token, login, logout, refreshAuth, setToken: setTokenState, currentOrg, setCurrentOrg: setCurrentOrgState, profile, loadProfile, setProfile: setProfileState }}>
       {children}
     </AuthContext.Provider>
   );

--- a/frontend/src/pages/AddMember.js
+++ b/frontend/src/pages/AddMember.js
@@ -1,5 +1,5 @@
-import React, { useState, useContext } from 'react';
-import { TextField, Button, Stack, Typography, Box } from '@mui/material';
+import React, { useState, useContext, useEffect } from 'react';
+import { TextField, Button, Stack, Typography, Box, Autocomplete } from '@mui/material';
 import { styles } from '../styles';
 import api from '../api';
 import { AuthContext } from '../AuthContext';
@@ -8,7 +8,21 @@ export default function AddMember() {
   useContext(AuthContext);
   const [orgId, setOrgId] = useState('');
   const [userId, setUserId] = useState('');
+  const [orgs, setOrgs] = useState([]);
+  const [users, setUsers] = useState([]);
   const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    const load = async () => {
+      const [oRes, uRes] = await Promise.all([
+        api.get('/organizations'),
+        api.get('/users')
+      ]);
+      setOrgs(oRes.data.map(o => ({ id: o.id, name: o.name })));
+      setUsers(uRes.data.map(u => ({ id: u.id, username: u.username })));
+    };
+    load();
+  }, []);
 
   const submit = async (e) => {
     e.preventDefault();
@@ -27,19 +41,17 @@ export default function AddMember() {
     <Box component="form" onSubmit={submit} noValidate>
       <Typography variant="h6" gutterBottom>Add Member</Typography>
       <Stack spacing={2} sx={styles.formStack}>
-        <TextField
-          label="Org ID"
-          placeholder="Org ID"
-          value={orgId}
-          onChange={e => setOrgId(e.target.value)}
-          required
+        <Autocomplete
+          options={orgs}
+          getOptionLabel={o => o.name || ''}
+          onChange={(_, v) => setOrgId(v ? v.id : '')}
+          renderInput={params => <TextField {...params} label="Organization" required />}
         />
-        <TextField
-          label="User ID"
-          placeholder="User ID"
-          value={userId}
-          onChange={e => setUserId(e.target.value)}
-          required
+        <Autocomplete
+          options={users}
+          getOptionLabel={u => u.username || ''}
+          onChange={(_, v) => setUserId(v ? v.id : '')}
+          renderInput={params => <TextField {...params} label="User" required />}
         />
         <Button type="submit" variant="contained">Submit</Button>
         {message && (

--- a/frontend/src/pages/Administration.js
+++ b/frontend/src/pages/Administration.js
@@ -1,26 +1,31 @@
-import React, { useState } from 'react';
+import React, { useState, useContext } from 'react';
 import { Tabs, Tab, Box } from '@mui/material';
 import { styles } from '../styles';
 import ManageUsers from './ManageUsers';
 import ManageRoles from './ManageRoles';
 import ManageOrganizations from './ManageOrganizations';
 import ManageInvites from './ManageInvites';
+import { AuthContext } from '../AuthContext';
 
 export default function Administration() {
+  const { profile } = useContext(AuthContext);
   const [tab, setTab] = useState(0);
+  const showOrgs = profile?.isSuperAdmin;
+  const isAdmin = profile?.isSuperAdmin || profile?.roles?.includes('ADMIN');
+  if (!isAdmin) return <Box>Not authorized</Box>;
   return (
     <Box>
       <Tabs value={tab} onChange={(_, v) => setTab(v)}>
         <Tab label="Users" />
         <Tab label="Roles" />
-        <Tab label="Organizations" />
+        {showOrgs && <Tab label="Organizations" />}
         <Tab label="Invites" />
       </Tabs>
       <Box sx={styles.actionRow}>
         {tab === 0 && <ManageUsers />}
         {tab === 1 && <ManageRoles />}
-        {tab === 2 && <ManageOrganizations />}
-        {tab === 3 && <ManageInvites />}
+        {showOrgs && tab === 2 && <ManageOrganizations />}
+        {(showOrgs ? tab === 3 : tab === 2) && <ManageInvites />}
       </Box>
     </Box>
   );

--- a/frontend/src/pages/Balance.js
+++ b/frontend/src/pages/Balance.js
@@ -6,21 +6,21 @@ import { AuthContext } from '../AuthContext';
 
 export default function Balance() {
   const { currentOrg } = useContext(AuthContext);
-  const [balance, setBalance] = useState(null);
+  const [balances, setBalances] = useState([]);
 
   useEffect(() => {
     const load = async () => {
-      const res = await api.get('/balance', { params: { orgId: currentOrg } });
-      setBalance(res.data.balance);
+      const res = await api.get('/balance');
+      setBalances(res.data.balances);
     };
-    if (currentOrg) {
-      load();
-    }
+    load();
   }, [currentOrg]);
   return (
     <Box>
       <Typography variant="h6" gutterBottom>Balance</Typography>
-      {balance !== null && <Typography>Balance: {balance}</Typography>}
+      {balances.map(b => (
+        <Typography key={b.orgId}>{b.orgName || b.orgId}: {b.amount}</Typography>
+      ))}
     </Box>
   );
 }

--- a/frontend/src/pages/CreateSuperAdmin.js
+++ b/frontend/src/pages/CreateSuperAdmin.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import api from '../api';
 import { TextField, Button, Stack, Typography, Box } from '@mui/material';
 import { styles } from '../styles';
@@ -6,6 +7,7 @@ import { styles } from '../styles';
 export default function CreateSuperAdmin() {
   const [form, setForm] = useState({ username: '', password: '', email: '', firstName: '', lastName: '' });
   const [message, setMessage] = useState('');
+  const navigate = useNavigate();
 
   const submit = async (e) => {
     e.preventDefault();
@@ -16,7 +18,7 @@ export default function CreateSuperAdmin() {
     }
     try {
       await api.post('/superadmin', trimmed);
-      setMessage('Super admin created');
+      navigate('/login');
     } catch (err) {
       setMessage(err.response?.data?.message || 'Creation failed');
     }

--- a/frontend/src/pages/ManageInvites.js
+++ b/frontend/src/pages/ManageInvites.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useMemo, useContext } from 'react';
-import { Box, Typography, IconButton, TextField, Button, Stack } from '@mui/material';
+import { Box, Typography, IconButton, TextField, Button, Stack, Autocomplete } from '@mui/material';
 import { styles } from '../styles';
 import DeleteIcon from '@mui/icons-material/Delete';
 import { useTable } from 'react-table';
@@ -13,6 +13,7 @@ export default function ManageInvites() {
   const [email, setEmail] = useState('');
   const [viewOrgId, setViewOrgId] = useState('');
   const [orgInvites, setOrgInvites] = useState([]);
+  const [allOrgs, setAllOrgs] = useState([]);
   const [message, setMessage] = useState('');
 
   useEffect(() => {
@@ -23,6 +24,14 @@ export default function ManageInvites() {
     };
     load();
   }, [currentOrg]);
+
+  useEffect(() => {
+    const loadOrgs = async () => {
+      const res = await api.get('/organizations');
+      setAllOrgs(res.data.map(o => ({ id: o.id, name: o.name })));
+    };
+    loadOrgs();
+  }, []);
 
   const deleteInvite = async (id) => {
     await api.delete(`/invites/${id}`);
@@ -94,13 +103,12 @@ export default function ManageInvites() {
       <Box sx={styles.actionRow}>
       <Box component="form" onSubmit={sendInvite} noValidate sx={{ mt: 2 }}>
         <Stack direction="row" spacing={1}>
-          <TextField
-            size="small"
-            label="Org ID"
-            placeholder="Org ID"
-            value={orgId}
-            onChange={e => setOrgId(e.target.value)}
-            required
+          <Autocomplete
+            options={allOrgs}
+            getOptionLabel={o => o.name || ''}
+            onChange={(_, v) => setOrgId(v ? v.id : '')}
+            renderInput={params => <TextField {...params} size="small" label="Organization" required />}
+            sx={{ width: 200 }}
           />
           <TextField
             size="small"
@@ -114,12 +122,12 @@ export default function ManageInvites() {
         </Stack>
       </Box>
         <Stack direction="row" spacing={1} sx={{ mt: 2 }}>
-          <TextField
-            size="small"
-            label="Org ID"
-            placeholder="Org ID"
-            value={viewOrgId}
-            onChange={e => setViewOrgId(e.target.value)}
+          <Autocomplete
+            options={allOrgs}
+            getOptionLabel={o => o.name || ''}
+            onChange={(_, v) => setViewOrgId(v ? v.id : '')}
+            renderInput={params => <TextField {...params} size="small" label="Organization" />}
+            sx={{ width: 200 }}
           />
           <Button variant="contained" onClick={loadOrgInvites}>View Invites</Button>
         </Stack>

--- a/frontend/src/pages/Register.js
+++ b/frontend/src/pages/Register.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import api from '../api';
 import {
   TextField,
@@ -12,6 +13,7 @@ import { styles } from '../styles';
 export default function Register() {
   const [form, setForm] = useState({ username: '', password: '', email: '', firstName: '', lastName: '' });
   const [message, setMessage] = useState('');
+  const navigate = useNavigate();
 
   const submit = async (e) => {
     e.preventDefault();
@@ -22,7 +24,7 @@ export default function Register() {
     }
     try {
       await api.post('/register', trimmed);
-      setMessage('Registered');
+      navigate('/login');
     } catch (err) {
       setMessage(err.response?.data?.message || 'Registration failed');
     }

--- a/frontend/src/pages/RemoveMember.js
+++ b/frontend/src/pages/RemoveMember.js
@@ -1,5 +1,5 @@
-import React, { useState, useContext } from 'react';
-import { TextField, Button, Stack, Typography, Box } from '@mui/material';
+import React, { useState, useContext, useEffect } from 'react';
+import { TextField, Button, Stack, Typography, Box, Autocomplete } from '@mui/material';
 import { styles } from '../styles';
 import api from '../api';
 import { AuthContext } from '../AuthContext';
@@ -8,7 +8,21 @@ export default function RemoveMember() {
   useContext(AuthContext);
   const [orgId, setOrgId] = useState('');
   const [userId, setUserId] = useState('');
+  const [orgs, setOrgs] = useState([]);
+  const [users, setUsers] = useState([]);
   const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    const load = async () => {
+      const [oRes, uRes] = await Promise.all([
+        api.get('/organizations'),
+        api.get('/users')
+      ]);
+      setOrgs(oRes.data.map(o => ({ id: o.id, name: o.name })));
+      setUsers(uRes.data.map(u => ({ id: u.id, username: u.username })));
+    };
+    load();
+  }, []);
 
   const submit = async (e) => {
     e.preventDefault();
@@ -27,19 +41,17 @@ export default function RemoveMember() {
     <Box component="form" onSubmit={submit} noValidate>
       <Typography variant="h6" gutterBottom>Remove Member</Typography>
       <Stack spacing={2} sx={styles.formStack}>
-        <TextField
-          label="Org ID"
-          placeholder="Org ID"
-          value={orgId}
-          onChange={e => setOrgId(e.target.value)}
-          required
+        <Autocomplete
+          options={orgs}
+          getOptionLabel={o => o.name || ''}
+          onChange={(_, v) => setOrgId(v ? v.id : '')}
+          renderInput={params => <TextField {...params} label="Organization" required />}
         />
-        <TextField
-          label="User ID"
-          placeholder="User ID"
-          value={userId}
-          onChange={e => setUserId(e.target.value)}
-          required
+        <Autocomplete
+          options={users}
+          getOptionLabel={u => u.username || ''}
+          onChange={(_, v) => setUserId(v ? v.id : '')}
+          renderInput={params => <TextField {...params} label="User" required />}
         />
         <Button type="submit" variant="contained">Submit</Button>
         {message && (

--- a/frontend/src/pages/Transfer.js
+++ b/frontend/src/pages/Transfer.js
@@ -1,4 +1,4 @@
-import React, { useState, useContext } from 'react';
+import React, { useState, useContext, useEffect } from 'react';
 import { TextField, Button, Stack, Typography, Box } from '@mui/material';
 import { styles } from '../styles';
 import api from '../api';
@@ -9,6 +9,17 @@ export default function Transfer() {
   const [toUsername, setTo] = useState('');
   const [amount, setAmount] = useState('');
   const [message, setMessage] = useState('');
+  const [balance, setBalance] = useState(null);
+
+  useEffect(() => {
+    const load = async () => {
+      if (currentOrg) {
+        const res = await api.get('/balance', { params: { orgId: currentOrg } });
+        setBalance(res.data.balance);
+      }
+    };
+    load();
+  }, [currentOrg]);
 
   const submit = async (e) => {
     e.preventDefault();
@@ -19,6 +30,8 @@ export default function Transfer() {
     try {
       await api.post('/transfer', { toUsername: toUsername.trim(), amount, orgId: currentOrg });
       setMessage('Transfer complete');
+      const res = await api.get('/balance', { params: { orgId: currentOrg } });
+      setBalance(res.data.balance);
     } catch (err) {
       setMessage(err.response?.data?.message || 'Transfer failed');
     }
@@ -42,6 +55,9 @@ export default function Transfer() {
           required
         />
         <Button type="submit" variant="contained">Submit</Button>
+        {balance !== null && (
+          <Typography>Current Balance: {balance}</Typography>
+        )}
         {message && (
           <Typography role="status" aria-live="polite">{message}</Typography>
         )}

--- a/frontend/src/pages/UpdateProfile.js
+++ b/frontend/src/pages/UpdateProfile.js
@@ -1,13 +1,16 @@
 import React, { useState, useContext } from 'react';
-import { TextField, Button, Stack, Typography, Box } from '@mui/material';
+import { useNavigate } from 'react-router-dom';
+import { TextField, Button, Stack, Typography, Box, Avatar } from '@mui/material';
 import { styles } from '../styles';
 import api from '../api';
 import { AuthContext } from '../AuthContext';
 
 export default function UpdateProfile() {
-  useContext(AuthContext);
+  const { loadProfile } = useContext(AuthContext);
+  const navigate = useNavigate();
   const [form, setForm] = useState({ username: '', firstName: '', lastName: '' });
   const [file, setFile] = useState(null);
+  const [preview, setPreview] = useState('');
   const [message, setMessage] = useState('');
 
   const submit = async (e) => {
@@ -19,6 +22,8 @@ export default function UpdateProfile() {
       headers: { 'Content-Type': 'multipart/form-data' }
     });
     setMessage('Profile updated');
+    await loadProfile();
+    navigate('/profile');
   };
   return (
     <Box component="form" onSubmit={submit} noValidate>
@@ -35,8 +40,23 @@ export default function UpdateProfile() {
         ))}
         <Button variant="contained" component="label">
           Upload Picture
-          <input type="file" hidden onChange={e => setFile(e.target.files[0])} />
+          <input
+            type="file"
+            hidden
+            onChange={e => {
+              const f = e.target.files[0];
+              setFile(f);
+              if (f) {
+                const reader = new FileReader();
+                reader.onload = ev => setPreview(ev.target.result);
+                reader.readAsDataURL(f);
+              } else {
+                setPreview('');
+              }
+            }}
+          />
         </Button>
+        {preview && <Avatar src={preview} sx={{ width: 80, height: 80 }} />}
         <Button type="submit" variant="contained">Submit</Button>
         {message && (
           <Typography role="status" aria-live="polite">{message}</Typography>


### PR DESCRIPTION
## Summary
- allow multiple roles per user and adjust admin check
- always show **All** org option and only show Administration if admin
- list balances for all organizations
- view and accept invites from a table

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68633d89a1f883268d69c377467abdcc