### PR TITLE
UI fixes for organization management

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -110,13 +110,14 @@ export default function App() {
             )}
             {token && (
               <FormControl size="small" sx={{ minWidth: 120 }}>
-                <InputLabel id="org-select-label">Org</InputLabel>
+                <InputLabel id="org-select-label">Organizations</InputLabel>
                 <Select
                   labelId="org-select-label"
                   value={currentOrg}
-                  label="Org"
+                  label="Organizations"
                   onChange={changeOrg}
                 >
+                  <MenuItem value="">None</MenuItem>
                   {orgs.map(o => (
                     <MenuItem key={o.id} value={o.id}>{o.name}</MenuItem>
                   ))}

--- a/frontend/src/pages/AcceptInvite.js
+++ b/frontend/src/pages/AcceptInvite.js
@@ -9,7 +9,7 @@ export default function AcceptInvite() {
   useContext(AuthContext);
   const [invites, setInvites] = useState([]);
   const [tokens, setTokens] = useState({});
-  const [message, setMessage] = useState('');
+  const [message, setMessage] = useState({ text: '', error: false });
 
   useEffect(() => {
     const load = async () => {
@@ -22,16 +22,17 @@ export default function AcceptInvite() {
   const accept = async (id) => {
     try {
       await api.post(`/invites/${id}/accept`, { token: tokens[id] });
-      setMessage('Invite accepted');
+      setMessage({ text: 'Invite accepted', error: false });
       setInvites(invites.filter(i => i.id !== id));
     } catch (err) {
-      setMessage(err.response?.data?.message || 'Error accepting invite');
+      setMessage({ text: err.response?.data?.message || 'Error accepting invite', error: true });
     }
   };
 
   const columns = React.useMemo(() => [
     { Header: 'ID', accessor: 'id' },
     { Header: 'Organization', accessor: 'org' },
+    { Header: 'Role', accessor: 'role' },
     {
       Header: 'Token',
       accessor: 'tokenInput',
@@ -77,7 +78,7 @@ export default function AcceptInvite() {
           })}
         </Box>
       </Box>
-      {message && <Typography role="status" aria-live="polite" sx={{ mt: 2 }}>{message}</Typography>}
+      {message.text && <Typography role="status" aria-live="polite" sx={{ mt: 2 }} color={message.error ? 'error' : undefined}>{message.text}</Typography>}
     </Box>
   );
 }

--- a/frontend/src/pages/AddMember.js
+++ b/frontend/src/pages/AddMember.js
@@ -10,7 +10,7 @@ export default function AddMember() {
   const [userId, setUserId] = useState('');
   const [orgs, setOrgs] = useState([]);
   const [users, setUsers] = useState([]);
-  const [message, setMessage] = useState('');
+  const [message, setMessage] = useState({ text: '', error: false });
 
   useEffect(() => {
     const load = async () => {
@@ -27,14 +27,14 @@ export default function AddMember() {
   const submit = async (e) => {
     e.preventDefault();
     if (!orgId || !userId) {
-      setMessage('Org and user IDs are required');
+      setMessage({ text: 'Org and user IDs are required', error: true });
       return;
     }
     try {
       await api.post(`/organizations/${orgId}/members`, { userId });
-      setMessage('Member added');
+      setMessage({ text: 'Member added', error: false });
     } catch (err) {
-      setMessage(err.response?.data?.message || 'Error adding member');
+      setMessage({ text: err.response?.data?.message || 'Error adding member', error: true });
     }
   };
   return (
@@ -54,8 +54,8 @@ export default function AddMember() {
           renderInput={params => <TextField {...params} label="User" required />}
         />
         <Button type="submit" variant="contained">Submit</Button>
-        {message && (
-          <Typography role="status" aria-live="polite">{message}</Typography>
+        {message.text && (
+          <Typography role="status" aria-live="polite" color={message.error ? 'error' : undefined}>{message.text}</Typography>
         )}
       </Stack>
     </Box>

--- a/frontend/src/pages/Administration.js
+++ b/frontend/src/pages/Administration.js
@@ -13,20 +13,20 @@ export default function Administration() {
   const showOrgs = profile?.isSuperAdmin;
   const isAdmin = profile?.isSuperAdmin || profile?.roles?.includes('ADMIN');
   if (!isAdmin) return <Box>Not authorized</Box>;
+  const tabs = [];
+  if (currentOrg) tabs.push({ label: 'Users', component: <ManageUsers /> });
+  if (currentOrg) tabs.push({ label: 'Roles', component: <ManageRoles /> });
+  if (showOrgs) tabs.push({ label: 'Organizations', component: <ManageOrganizations /> });
+  if (currentOrg) tabs.push({ label: 'Invites', component: <ManageInvites /> });
+
   return (
     <Box>
       <Tabs value={tab} onChange={(_, v) => setTab(v)}>
-        <Tab label="Users" />
-        {currentOrg && <Tab label="Roles" />}
-        {showOrgs && <Tab label="Organizations" />}
-        {currentOrg && <Tab label="Invites" />}
+        {tabs.map(t => (
+          <Tab key={t.label} label={t.label} />
+        ))}
       </Tabs>
-      <Box sx={styles.actionRow}>
-        {tab === 0 && <ManageUsers />}
-        {currentOrg && tab === 1 && <ManageRoles />}
-        {showOrgs && ((currentOrg ? tab === 2 : tab === 1)) && <ManageOrganizations />}
-        {currentOrg && ((showOrgs ? tab === 3 : tab === 2)) && <ManageInvites />}
-      </Box>
+      <Box sx={styles.actionRow}>{tabs[tab]?.component}</Box>
     </Box>
   );
 }

--- a/frontend/src/pages/Balance.js
+++ b/frontend/src/pages/Balance.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useContext } from 'react';
-import { Typography, Box, Card, CardContent, Stack } from '@mui/material';
+import { Typography, Box } from '@mui/material';
 import { styles } from '../styles';
 import api from '../api';
 import { AuthContext } from '../AuthContext';
@@ -23,11 +23,7 @@ export default function Balance() {
     <Box>
       <Typography variant="h6" gutterBottom>Balance</Typography>
       {balance !== null && (
-        <Card>
-          <CardContent>
-            <Typography>Balance: {balance}</Typography>
-          </CardContent>
-        </Card>
+        <Typography>Balance: {balance}</Typography>
       )}
     </Box>
   );

--- a/frontend/src/pages/ChangePassword.js
+++ b/frontend/src/pages/ChangePassword.js
@@ -8,23 +8,23 @@ export default function ChangePassword() {
   useContext(AuthContext);
   const [oldPassword, setOld] = useState('');
   const [newPassword, setNew] = useState('');
-  const [message, setMessage] = useState('');
+  const [message, setMessage] = useState({ text: '', error: false });
 
   const submit = async (e) => {
     e.preventDefault();
     if (!oldPassword || !newPassword) {
-      setMessage('Both fields are required');
+      setMessage({ text: 'Both fields are required', error: true });
       return;
     }
     await api.post('/password/change', { oldPassword, newPassword });
-    setMessage('Password changed');
+    setMessage({ text: 'Password changed', error: false });
   };
   return (
     <Box component="form" onSubmit={submit} noValidate>
       <Typography variant="h6" gutterBottom>Change Password</Typography>
       <Stack spacing={2} sx={styles.formStack}>
         <TextField
-          label="old password"
+          label="Old Password"
           placeholder="Old Password"
           type="password"
           value={oldPassword}
@@ -32,7 +32,7 @@ export default function ChangePassword() {
           required
         />
         <TextField
-          label="new password"
+          label="New Password"
           placeholder="New Password"
           type="password"
           value={newPassword}
@@ -40,8 +40,8 @@ export default function ChangePassword() {
           required
         />
         <Button type="submit" variant="contained">Submit</Button>
-        {message && (
-          <Typography role="status" aria-live="polite">{message}</Typography>
+        {message.text && (
+          <Typography role="status" aria-live="polite" color={message.error ? 'error' : undefined}>{message.text}</Typography>
         )}
       </Stack>
     </Box>

--- a/frontend/src/pages/CreateOrganization.js
+++ b/frontend/src/pages/CreateOrganization.js
@@ -7,31 +7,31 @@ import { AuthContext } from '../AuthContext';
 export default function CreateOrganization() {
   useContext(AuthContext);
   const [name, setName] = useState('');
-  const [message, setMessage] = useState('');
+  const [message, setMessage] = useState({ text: '', error: false });
 
   const submit = async (e) => {
     e.preventDefault();
     if (!name) {
-      setMessage('Name is required');
+      setMessage({ text: 'Name is required', error: true });
       return;
     }
     await api.post('/organizations', { name });
-    setMessage('Organization created');
+    setMessage({ text: 'Organization created', error: false });
   };
   return (
     <Box component="form" onSubmit={submit} noValidate>
       <Typography variant="h6" gutterBottom>Create Organization</Typography>
       <Stack spacing={2} sx={styles.formStack}>
         <TextField
-          label="name"
+          label="Name"
           placeholder="Name"
           value={name}
           onChange={e => setName(e.target.value)}
           required
         />
         <Button type="submit" variant="contained">Submit</Button>
-        {message && (
-          <Typography role="status" aria-live="polite">{message}</Typography>
+        {message.text && (
+          <Typography role="status" aria-live="polite" color={message.error ? 'error' : undefined}>{message.text}</Typography>
         )}
       </Stack>
     </Box>

--- a/frontend/src/pages/CreateSuperAdmin.js
+++ b/frontend/src/pages/CreateSuperAdmin.js
@@ -6,21 +6,21 @@ import { styles } from '../styles';
 
 export default function CreateSuperAdmin() {
   const [form, setForm] = useState({ username: '', password: '', email: '', firstName: '', lastName: '' });
-  const [message, setMessage] = useState('');
+  const [message, setMessage] = useState({ text: '', error: false });
   const navigate = useNavigate();
 
   const submit = async (e) => {
     e.preventDefault();
     const trimmed = { ...form, username: form.username.trim() };
     if (Object.values(trimmed).some(v => !v)) {
-      setMessage('All fields are required');
+      setMessage({ text: 'All fields are required', error: true });
       return;
     }
     try {
       await api.post('/superadmin', trimmed);
       navigate('/login');
     } catch (err) {
-      setMessage(err.response?.data?.message || 'Creation failed');
+      setMessage({ text: err.response?.data?.message || 'Creation failed', error: true });
     }
   };
 
@@ -42,8 +42,8 @@ export default function CreateSuperAdmin() {
           />
         ))}
         <Button type="submit" variant="contained">Submit</Button>
-        {message && (
-          <Typography role="status" aria-live="polite">{message}</Typography>
+        {message.text && (
+          <Typography role="status" aria-live="polite" color={message.error ? 'error' : undefined}>{message.text}</Typography>
         )}
       </Stack>
     </Box>

--- a/frontend/src/pages/ForgotPassword.js
+++ b/frontend/src/pages/ForgotPassword.js
@@ -6,17 +6,17 @@ import api from '../api';
 export default function ForgotPassword() {
   const [username, setUsername] = useState('');
   const [token, setToken] = useState('');
-  const [message, setMessage] = useState('');
+  const [message, setMessage] = useState({ text: '', error: false });
 
   const submit = async (e) => {
     e.preventDefault();
     if (!username.trim()) {
-      setMessage('Username is required');
+      setMessage({ text: 'Username is required', error: true });
       return;
     }
     const res = await api.post('/password/forgot', { username: username.trim() });
     setToken(res.data.token);
-    setMessage('Token created');
+    setMessage({ text: 'Token created', error: false });
   };
 
   return (
@@ -24,7 +24,7 @@ export default function ForgotPassword() {
       <Typography variant="h6" gutterBottom>Forgot Password</Typography>
       <Stack spacing={2} sx={styles.formStack}>
         <TextField
-          label="username"
+          label="Username"
           placeholder="Username"
           value={username}
           onChange={e => setUsername(e.target.value)}
@@ -33,8 +33,8 @@ export default function ForgotPassword() {
         />
         <Button type="submit" variant="contained">Request Reset Token</Button>
         {token && <Typography>Reset Token: {token}</Typography>}
-        {message && (
-          <Typography role="status" aria-live="polite">{message}</Typography>
+        {message.text && (
+          <Typography role="status" aria-live="polite" color={message.error ? 'error' : undefined}>{message.text}</Typography>
         )}
       </Stack>
     </Box>

--- a/frontend/src/pages/InviteUser.js
+++ b/frontend/src/pages/InviteUser.js
@@ -1,5 +1,5 @@
 import React, { useState, useContext } from 'react';
-import { TextField, Button, Stack, Typography, Box } from '@mui/material';
+import { TextField, Button, Stack, Typography, Box, Select, MenuItem } from '@mui/material';
 import { styles } from '../styles';
 import api from '../api';
 import { AuthContext } from '../AuthContext';
@@ -8,19 +8,20 @@ export default function InviteUser() {
   useContext(AuthContext);
   const [orgId, setOrgId] = useState('');
   const [email, setEmail] = useState('');
-  const [message, setMessage] = useState('');
+  const [role, setRole] = useState('USER');
+  const [message, setMessage] = useState({ text: '', error: false });
 
   const submit = async (e) => {
     e.preventDefault();
     if (!orgId || !email) {
-      setMessage('Org ID and email are required');
+      setMessage({ text: 'Org ID and email are required', error: true });
       return;
     }
     try {
-      await api.post(`/organizations/${orgId}/invite`, { email });
-      setMessage('Invite sent');
+      await api.post(`/organizations/${orgId}/invite`, { email, role });
+      setMessage({ text: 'Invite sent', error: false });
     } catch (err) {
-      setMessage(err.response?.data?.message || 'Error sending invite');
+      setMessage({ text: err.response?.data?.message || 'Error sending invite', error: true });
     }
   };
   return (
@@ -41,9 +42,17 @@ export default function InviteUser() {
           onChange={e => setEmail(e.target.value)}
           required
         />
+        <Select
+          value={role}
+          onChange={e => setRole(e.target.value)}
+          size="small"
+        >
+          <MenuItem value="USER">USER</MenuItem>
+          <MenuItem value="ADMIN">ADMIN</MenuItem>
+        </Select>
         <Button type="submit" variant="contained">Submit</Button>
-        {message && (
-          <Typography role="status" aria-live="polite">{message}</Typography>
+        {message.text && (
+          <Typography role="status" aria-live="polite" color={message.error ? 'error' : undefined}>{message.text}</Typography>
         )}
       </Stack>
     </Box>

--- a/frontend/src/pages/Login.js
+++ b/frontend/src/pages/Login.js
@@ -17,25 +17,25 @@ export default function Login() {
   const navigate = useNavigate();
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
-  const [message, setMessage] = useState('');
+  const [message, setMessage] = useState({ text: '', error: false });
 
   const submit = async (e) => {
     e.preventDefault();
     if (!username.trim() || !password) {
-      setMessage('Username and password are required');
+      setMessage({ text: 'Username and password are required', error: true });
       return;
     }
     try {
       await login(username.trim(), password);
       const orgRes = await api.get('/user/organizations');
-      setMessage('Logged in');
+      setMessage({ text: 'Logged in', error: false });
       if (orgRes.data.organizations.length === 0) {
         navigate('/accept-invite');
       } else {
         navigate('/balance');
       }
     } catch (err) {
-      setMessage(err.response?.data?.message || 'Login failed');
+      setMessage({ text: err.response?.data?.message || 'Login failed', error: true });
     }
   };
   return (
@@ -43,7 +43,7 @@ export default function Login() {
       <Typography variant="h6" gutterBottom>Login</Typography>
       <Stack spacing={2} sx={styles.formStack}>
         <TextField
-          label="username"
+          label="Username"
           placeholder="Username"
           inputProps={{ maxLength: 20 }}
           value={username}
@@ -52,7 +52,7 @@ export default function Login() {
         />
         <TextField
           type="password"
-          label="password"
+          label="Password"
           placeholder="Password"
           value={password}
           onChange={e => setPassword(e.target.value)}
@@ -60,8 +60,8 @@ export default function Login() {
         />
         <Button type="submit" variant="contained">Submit</Button>
         <Link href="/forgot-password" underline="hover">Forgot password?</Link>
-        {message && (
-          <Typography role="status" aria-live="polite">{message}</Typography>
+        {message.text && (
+          <Typography role="status" aria-live="polite" color={message.error ? 'error' : undefined}>{message.text}</Typography>
         )}
       </Stack>
     </Box>

--- a/frontend/src/pages/ManageOrganizations.js
+++ b/frontend/src/pages/ManageOrganizations.js
@@ -102,7 +102,7 @@ export default function ManageOrganizations() {
       <Stack direction="row" spacing={1} sx={{ mt: 2 }}>
         <TextField
           size="small"
-          label="name"
+          label="Name"
           placeholder="Name"
           value={newName}
           onChange={e => setNewName(e.target.value)}

--- a/frontend/src/pages/Register.js
+++ b/frontend/src/pages/Register.js
@@ -12,21 +12,21 @@ import { styles } from '../styles';
 
 export default function Register() {
   const [form, setForm] = useState({ username: '', password: '', email: '', firstName: '', lastName: '' });
-  const [message, setMessage] = useState('');
+  const [message, setMessage] = useState({ text: '', error: false });
   const navigate = useNavigate();
 
   const submit = async (e) => {
     e.preventDefault();
     const trimmed = { ...form, username: form.username.trim() };
     if (Object.values(trimmed).some(v => !v)) {
-      setMessage('All fields are required');
+      setMessage({ text: 'All fields are required', error: true });
       return;
     }
     try {
       await api.post('/register', trimmed);
       navigate('/login');
     } catch (err) {
-      setMessage(err.response?.data?.message || 'Registration failed');
+      setMessage({ text: err.response?.data?.message || 'Registration failed', error: true });
     }
   };
   return (
@@ -47,8 +47,8 @@ export default function Register() {
           />
         ))}
         <Button type="submit" variant="contained">Submit</Button>
-        {message && (
-          <Typography role="status" aria-live="polite">{message}</Typography>
+        {message.text && (
+          <Typography role="status" aria-live="polite" color={message.error ? 'error' : undefined}>{message.text}</Typography>
         )}
       </Stack>
     </Box>

--- a/frontend/src/pages/RemoveMember.js
+++ b/frontend/src/pages/RemoveMember.js
@@ -10,7 +10,7 @@ export default function RemoveMember() {
   const [userId, setUserId] = useState('');
   const [orgs, setOrgs] = useState([]);
   const [users, setUsers] = useState([]);
-  const [message, setMessage] = useState('');
+  const [message, setMessage] = useState({ text: '', error: false });
 
   useEffect(() => {
     const load = async () => {
@@ -27,14 +27,14 @@ export default function RemoveMember() {
   const submit = async (e) => {
     e.preventDefault();
     if (!orgId || !userId) {
-      setMessage('Org and user IDs are required');
+      setMessage({ text: 'Org and user IDs are required', error: true });
       return;
     }
     try {
       await api.delete(`/organizations/${orgId}/members/${userId}`);
-      setMessage('Member removed');
+      setMessage({ text: 'Member removed', error: false });
     } catch (err) {
-      setMessage(err.response?.data?.message || 'Error removing member');
+      setMessage({ text: err.response?.data?.message || 'Error removing member', error: true });
     }
   };
   return (
@@ -54,8 +54,8 @@ export default function RemoveMember() {
           renderInput={params => <TextField {...params} label="User" required />}
         />
         <Button type="submit" variant="contained">Submit</Button>
-        {message && (
-          <Typography role="status" aria-live="polite">{message}</Typography>
+        {message.text && (
+          <Typography role="status" aria-live="polite" color={message.error ? 'error' : undefined}>{message.text}</Typography>
         )}
       </Stack>
     </Box>

--- a/frontend/src/pages/ResetPassword.js
+++ b/frontend/src/pages/ResetPassword.js
@@ -6,16 +6,16 @@ import api from '../api';
 export default function ResetPassword() {
   const [token, setToken] = useState('');
   const [password, setPassword] = useState('');
-  const [message, setMessage] = useState('');
+  const [message, setMessage] = useState({ text: '', error: false });
 
   const submit = async (e) => {
     e.preventDefault();
     if (!token || !password) {
-      setMessage('Token and new password are required');
+      setMessage({ text: 'Token and new password are required', error: true });
       return;
     }
     await api.post('/password/reset', { token, newPassword: password });
-    setMessage('Password reset');
+    setMessage({ text: 'Password reset', error: false });
   };
 
   return (
@@ -23,7 +23,7 @@ export default function ResetPassword() {
       <Typography variant="h6" gutterBottom>Reset Password</Typography>
       <Stack spacing={2} sx={styles.formStack}>
         <TextField
-          label="reset token"
+          label="Reset Token"
           placeholder="Reset Token"
           value={token}
           onChange={e => setToken(e.target.value)}
@@ -31,15 +31,15 @@ export default function ResetPassword() {
         />
         <TextField
           type="password"
-          label="new password"
+          label="New Password"
           placeholder="New Password"
           value={password}
           onChange={e => setPassword(e.target.value)}
           required
         />
         <Button type="submit" variant="contained">Submit</Button>
-        {message && (
-          <Typography role="status" aria-live="polite">{message}</Typography>
+        {message.text && (
+          <Typography role="status" aria-live="polite" color={message.error ? 'error' : undefined}>{message.text}</Typography>
         )}
       </Stack>
     </Box>

--- a/frontend/src/pages/Transfer.js
+++ b/frontend/src/pages/Transfer.js
@@ -7,7 +7,7 @@ import { AuthContext } from '../AuthContext';
 export default function Transfer() {
   const [toUsername, setTo] = useState('');
   const [amount, setAmount] = useState('');
-  const [message, setMessage] = useState('');
+  const [message, setMessage] = useState({ text: '', error: false });
   const { currentOrg } = useContext(AuthContext);
   const [balance, setBalance] = useState(null);
 
@@ -26,16 +26,16 @@ export default function Transfer() {
   const submit = async (e) => {
     e.preventDefault();
     if (!toUsername.trim() || !amount || !currentOrg) {
-      setMessage('Recipient, amount, and organization are required');
+      setMessage({ text: 'Recipient, amount, and organization are required', error: true });
       return;
     }
     try {
       await api.post('/transfer', { toUsername: toUsername.trim(), amount, orgId: currentOrg });
-      setMessage('Transfer complete');
+      setMessage({ text: 'Transfer complete', error: false });
       const res = await api.get('/balance', { params: { orgId: currentOrg } });
       setBalance(res.data.balance);
     } catch (err) {
-      setMessage(err.response?.data?.message || 'Transfer failed');
+      setMessage({ text: err.response?.data?.message || 'Transfer failed', error: true });
     }
   };
   if (!currentOrg) return <Box />;
@@ -45,14 +45,14 @@ export default function Transfer() {
       <Typography variant="h6" gutterBottom>Transfer</Typography>
       <Stack spacing={2} sx={styles.formStack}>
         <TextField
-          label="to username"
+          label="To Username"
           placeholder="To Username"
           value={toUsername}
           onChange={e => setTo(e.target.value)}
           required
         />
         <TextField
-          label="amount"
+          label="Amount"
           placeholder="Amount"
           value={amount}
           onChange={e => setAmount(e.target.value)}
@@ -62,8 +62,8 @@ export default function Transfer() {
         {balance !== null && (
           <Typography>Current Balance: {balance}</Typography>
         )}
-        {message && (
-          <Typography role="status" aria-live="polite">{message}</Typography>
+        {message.text && (
+          <Typography role="status" aria-live="polite" color={message.error ? 'error' : undefined}>{message.text}</Typography>
         )}
       </Stack>
     </Box>


### PR DESCRIPTION
## Summary
- allow selecting `None` organization and rename dropdown
- enforce unique usernames when updating profile
- specify role when inviting users
- sync admin tables after CRUD actions and simplify manage users
- prefill profile form
- fix casing for form labels

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68634a8568888326a888aa5beb3963f2