### PR TITLE
Implement cascading org deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Copy this file to `.env` and modify values as needed.
 
 The frontend will be available on `FRONTEND_PORT`. It includes simple pages for each API endpoint under `src/index.js`, allowing you to register, log in, manage organizations and members, handle invites, transfer currency and update user roles.
 All API requests use an Axios instance defined in `src/api.js`. The authentication token is stored using React Context in `src/AuthContext.js`, which automatically adds the `Authorization` header for requests. Login now also returns a long-lived refresh token which the Axios wrapper uses to obtain a new access token when a request returns `401`. Profile updates now support uploading a picture and accepting an invite requires providing the invite's token.
-The UI uses Material UI components with an AppBar and side navigation drawer for a simple dashboard layout. When logged in, a dropdown in the header lists your organizations and the selection is stored only in the browser. Admin features live under an **Administration** page where tables built with `react-table` let you manage users, roles, organizations and invites inline.
+The UI uses Material UI components with an AppBar and side navigation drawer for a simple dashboard layout. When logged in, a dropdown in the header lists your organizations and the selection is stored only in the browser. Admin features live under an **Administration** page where tables built with `react-table` let you manage users, roles, organizations and invites inline. Super admins may access this page even without belonging to an organization or having roles assigned. Deleting an organization now also removes its roles, invites and any references from user documents.
 
 ## Docker
 


### PR DESCRIPTION
## Summary
- cascade delete roles and invites when an organization is removed
- remove organization references from users on org delete
- document that super admins can always reach administration and org deletions remove references

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68635784428c8326a0016b0d10854457