### PR TITLE
Fix login as landing page and clean form labels

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useContext } from 'react';
-import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom';
+import { BrowserRouter as Router, Routes, Route, Link, Navigate } from 'react-router-dom';
 import {
   AppBar,
   Toolbar,
@@ -53,7 +53,7 @@ export default function App() {
     { text: 'Create SuperAdmin', path: '/create-superadmin', icon: <AdminPanelSettings /> }
   ];
 
-  const { token, currentOrg, setCurrentOrg, profile, orgs, refreshOrgs } = useContext(AuthContext);
+  const { token, currentOrg, setCurrentOrg, profile, orgs, refreshOrgs, isAdmin } = useContext(AuthContext);
 
   const loggedInNav = [
     { text: 'Profile', path: '/profile', icon: <AccountCircle /> },
@@ -68,7 +68,7 @@ export default function App() {
   ];
   const adminNav = { text: 'Administration', path: '/admin', icon: <AdminPanelSettings /> };
   const navItems = token
-    ? [...loggedInNav, ...(profile && (profile.isSuperAdmin || profile.roles?.includes('ADMIN')) ? [adminNav] : [])]
+    ? [...loggedInNav, ...(profile && isAdmin ? [adminNav] : [])]
     : loggedOutNav;
 
   useEffect(() => {
@@ -153,7 +153,8 @@ export default function App() {
             <Route path="/logout" element={<LogoutPage />} />
             <Route path="/forgot-password" element={<ForgotPassword />} />
             <Route path="/reset-password" element={<ResetPassword />} />
-            <Route path="*" element={<div>Home</div>} />
+            <Route path="/" element={token ? <Balance /> : <Login />} />
+            <Route path="*" element={<Navigate to="/" replace />} />
           </Routes>
         </Box>
       </Box>

--- a/frontend/src/AuthContext.js
+++ b/frontend/src/AuthContext.js
@@ -88,6 +88,8 @@ export function AuthProvider({ children }) {
     setTokenState(res.data.token);
   };
 
+  const isAdmin = profile?.isSuperAdmin || profile?.roles?.includes('ADMIN');
+
   return (
     <AuthContext.Provider value={{
       token,
@@ -98,6 +100,7 @@ export function AuthProvider({ children }) {
       currentOrg,
       setCurrentOrg: setCurrentOrgState,
       profile,
+      isAdmin,
       loadProfile,
       setProfile: setProfileState,
       orgs,

--- a/frontend/src/pages/Administration.js
+++ b/frontend/src/pages/Administration.js
@@ -8,10 +8,9 @@ import ManageInvites from './ManageInvites';
 import { AuthContext } from '../AuthContext';
 
 export default function Administration() {
-  const { profile, currentOrg } = useContext(AuthContext);
+  const { profile, currentOrg, isAdmin } = useContext(AuthContext);
   const [tab, setTab] = useState(0);
   const showOrgs = profile?.isSuperAdmin;
-  const isAdmin = profile?.isSuperAdmin || profile?.roles?.includes('ADMIN');
   if (!isAdmin) return <Box>Not authorized</Box>;
   const tabs = [];
   if (currentOrg) tabs.push({ label: 'Users', component: <ManageUsers /> });

--- a/frontend/src/pages/CreateSuperAdmin.js
+++ b/frontend/src/pages/CreateSuperAdmin.js
@@ -5,7 +5,7 @@ import { TextField, Button, Stack, Typography, Box } from '@mui/material';
 import { styles } from '../styles';
 
 export default function CreateSuperAdmin() {
-  const [form, setForm] = useState({ username: '', password: '', email: '', firstName: '', lastName: '' });
+  const [form, setForm] = useState({ username: '', password: '', confirmPassword: '', email: '', firstName: '', lastName: '' });
   const [message, setMessage] = useState({ text: '', error: false });
   const navigate = useNavigate();
 
@@ -16,24 +16,35 @@ export default function CreateSuperAdmin() {
       setMessage({ text: 'All fields are required', error: true });
       return;
     }
+    if (trimmed.password !== trimmed.confirmPassword) {
+      setMessage({ text: 'Passwords do not match', error: true });
+      return;
+    }
+    const { confirmPassword, ...payload } = trimmed;
     try {
-      await api.post('/superadmin', trimmed);
+      await api.post('/superadmin', payload);
       navigate('/login');
     } catch (err) {
       setMessage({ text: err.response?.data?.message || 'Creation failed', error: true });
     }
   };
 
+  const formatLabel = (field) =>
+    field
+      .replace(/^(.)/, (c) => c.toUpperCase())
+      .replace(/([A-Z])/g, ' $1')
+      .trim();
+
   return (
     <Box component="form" onSubmit={submit} noValidate>
       <Typography variant="h6" gutterBottom>Create Super Admin</Typography>
       <Stack spacing={2} sx={styles.formStack}>
-        {['username','password','email','firstName','lastName'].map(f => (
+        {['username','password','confirmPassword','email','firstName','lastName'].map(f => (
           <TextField
             key={f}
-            type={f === 'password' ? 'password' : 'text'}
-            label={f}
-            placeholder={f.replace(/^(.)/, c => c.toUpperCase()).replace(/([A-Z])/g, ' $1').trim()}
+            type={['password','confirmPassword'].includes(f) ? 'password' : 'text'}
+            label={formatLabel(f)}
+            placeholder={formatLabel(f)}
             inputProps={f === 'username' ? { maxLength: 20 } : undefined}
             helperText={f === 'username' ? 'max 20 characters' : ''}
             value={form[f]}

--- a/frontend/src/pages/Register.js
+++ b/frontend/src/pages/Register.js
@@ -11,7 +11,7 @@ import {
 import { styles } from '../styles';
 
 export default function Register() {
-  const [form, setForm] = useState({ username: '', password: '', email: '', firstName: '', lastName: '' });
+  const [form, setForm] = useState({ username: '', password: '', confirmPassword: '', email: '', firstName: '', lastName: '' });
   const [message, setMessage] = useState({ text: '', error: false });
   const navigate = useNavigate();
 
@@ -22,23 +22,34 @@ export default function Register() {
       setMessage({ text: 'All fields are required', error: true });
       return;
     }
+    if (trimmed.password !== trimmed.confirmPassword) {
+      setMessage({ text: 'Passwords do not match', error: true });
+      return;
+    }
+    const { confirmPassword, ...payload } = trimmed;
     try {
-      await api.post('/register', trimmed);
+      await api.post('/register', payload);
       navigate('/login');
     } catch (err) {
       setMessage({ text: err.response?.data?.message || 'Registration failed', error: true });
     }
   };
+  const formatLabel = (field) =>
+    field
+      .replace(/^(.)/, (c) => c.toUpperCase())
+      .replace(/([A-Z])/g, ' $1')
+      .trim();
+
   return (
     <Box component="form" onSubmit={submit} noValidate>
       <Typography variant="h6" gutterBottom>Register</Typography>
       <Stack spacing={2} sx={styles.formStack}>
-        {['username','password','email','firstName','lastName'].map(f => (
+        {['username','password','confirmPassword','email','firstName','lastName'].map(f => (
           <TextField
             key={f}
-            type={f === 'password' ? 'password' : 'text'}
-            label={f}
-            placeholder={f.replace(/^(.)/, c => c.toUpperCase()).replace(/([A-Z])/g, ' $1').trim()}
+            type={['password','confirmPassword'].includes(f) ? 'password' : 'text'}
+            label={formatLabel(f)}
+            placeholder={formatLabel(f)}
             inputProps={f === 'username' ? { maxLength: 20 } : undefined}
             helperText={f === 'username' ? 'max 20 characters' : ''}
             value={form[f]}


### PR DESCRIPTION
## Summary
- route `/` to login when logged out and balance when logged in
- redirect all unmatched routes to `/`
- improve labels for register and super-admin forms
- add confirm password field to registration and super admin creation forms
- expose `isAdmin` through context so super admins always access admin pages

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686358fd0d6c8326ab4cd0cac0a4b45b