### PR TITLE
Update frontend user/org management

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -97,13 +97,15 @@ export default function App() {
                 {profile.profilePicture && (
                   <Avatar src={profile.profilePicture} sx={{ width: 32, height: 32, mr: 1 }} />
                 )}
-                {profile.firstName} {profile.lastName} | {profile.username} |
-                Current Balance: {profile.balances.find(b => b.orgId === currentOrg)?.amount ?? 0}
+                {profile.firstName} {profile.lastName} | {profile.username}
+                {currentOrg && (
+                  <> | Current Balance: {profile.balances.find(b => b.orgId === currentOrg)?.amount ?? 0}</>
+                )}
               </Typography>
             )}
             {token && (
               <FormControl size="small" sx={{ minWidth: 120 }}>
-                <InputLabel id="org-select-label">Organizations</InputLabel>
+                <InputLabel id="org-select-label" shrink>Organizations</InputLabel>
                 <Select
                   labelId="org-select-label"
                   value={currentOrg}

--- a/frontend/src/pages/AcceptInvite.js
+++ b/frontend/src/pages/AcceptInvite.js
@@ -6,7 +6,7 @@ import { styles } from '../styles';
 import api from '../api';
 
 export default function AcceptInvite() {
-  const { refreshOrgs } = useContext(AuthContext);
+  const { refreshOrgs, loadProfile } = useContext(AuthContext);
   const [invites, setInvites] = useState([]);
   const [tokens, setTokens] = useState({});
   const [message, setMessage] = useState({ text: '', error: false });
@@ -25,6 +25,7 @@ export default function AcceptInvite() {
       setMessage({ text: 'Invite accepted', error: false });
       setInvites(invites.filter(i => i.id !== id));
       refreshOrgs();
+      loadProfile();
     } catch (err) {
       setMessage({ text: err.response?.data?.message || 'Error accepting invite', error: true });
     }

--- a/frontend/src/pages/ManageUsers.js
+++ b/frontend/src/pages/ManageUsers.js
@@ -16,11 +16,11 @@ export default function ManageUsers() {
   const [removeUserId, setRemoveUserId] = useState('');
   const [message, setMessage] = useState({ text: '', error: false });
   const load = async () => {
-    if (!currentOrg) { setUsers([]); setRoles([]); return; }
-    const [uRes, rRes] = await Promise.all([
-      api.get('/users', { params: { orgId: currentOrg } }),
-      api.get('/roles', { params: { orgId: currentOrg } })
-    ]);
+    const userReq = currentOrg
+      ? api.get('/users', { params: { orgId: currentOrg } })
+      : api.get('/users');
+    const roleReq = api.get('/roles', { params: currentOrg ? { orgId: currentOrg } : {} });
+    const [uRes, rRes] = await Promise.all([userReq, roleReq]);
     setUsers(uRes.data);
     setRoles(rRes.data);
   };

--- a/frontend/src/pages/Profile.js
+++ b/frontend/src/pages/Profile.js
@@ -24,6 +24,7 @@ export default function Profile() {
             <Avatar src={profile.profilePicture} sx={{ width: 100, height: 100, mb: 2 }} />
           )}
           <Typography><strong>Username:</strong> {profile.username}</Typography>
+          <Typography><strong>Email:</strong> {profile.email}</Typography>
           <Typography><strong>Name:</strong> {profile.firstName} {profile.lastName}</Typography>
           <Typography><strong>Roles:</strong> {profile.roles.join(', ')}</Typography>
           <Typography sx={{ mt: 1 }}><strong>Balances:</strong></Typography>

--- a/frontend/src/pages/Transfer.js
+++ b/frontend/src/pages/Transfer.js
@@ -8,7 +8,7 @@ export default function Transfer() {
   const [toUsername, setTo] = useState('');
   const [amount, setAmount] = useState('');
   const [message, setMessage] = useState({ text: '', error: false });
-  const { currentOrg } = useContext(AuthContext);
+  const { currentOrg, loadProfile } = useContext(AuthContext);
   const [balance, setBalance] = useState(null);
 
   useEffect(() => {
@@ -34,6 +34,7 @@ export default function Transfer() {
       setMessage({ text: 'Transfer complete', error: false });
       const res = await api.get('/balance', { params: { orgId: currentOrg } });
       setBalance(res.data.balance);
+      loadProfile();
     } catch (err) {
       setMessage({ text: err.response?.data?.message || 'Transfer failed', error: true });
     }


### PR DESCRIPTION
## Summary
- refresh org and profile info in AcceptInvite and Transfer pages
- show email on Profile page
- load all users when no org selected in Manage Users
- hide balance when no org is selected
- fix select label overlap when no org

## Testing
- `npm test` *(fails: no tests specified)*

------
https://chatgpt.com/codex/tasks/task_e_68635e9eddc48326bee8c1ce35715de5