### PR TITLE
Enhance admin pages and cleanup styles

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -28,7 +28,8 @@ import {
   SwapHoriz,
   AccountBalanceWallet,
   AdminPanelSettings,
-  Logout
+  Logout,
+  LockReset
 } from '@mui/icons-material';
 import { styles } from './styles';
 import Register from './pages/Register';
@@ -50,7 +51,8 @@ export default function App() {
   const loggedOutNav = [
     { text: 'Register', path: '/register', icon: <PersonAdd /> },
     { text: 'Login', path: '/login', icon: <LoginIcon /> },
-    { text: 'Create SuperAdmin', path: '/create-superadmin', icon: <AdminPanelSettings /> }
+    { text: 'Create SuperAdmin', path: '/create-superadmin', icon: <AdminPanelSettings /> },
+    { text: 'Reset Password', path: '/reset-password', icon: <LockReset /> }
   ];
 
   const { token, currentOrg, setCurrentOrg, profile, orgs, refreshOrgs, isAdmin } = useContext(AuthContext);
@@ -131,7 +133,7 @@ export default function App() {
           <List>
             {navItems.map((item) => (
               <ListItem disablePadding key={item.text}>
-                <ListItemButton component={Link} to={item.path}>
+                <ListItemButton component={Link} to={item.path} sx={{ gap: 2 }}>
                   <ListItemIcon>{item.icon}</ListItemIcon>
                   <ListItemText primary={item.text} />
                 </ListItemButton>

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -2,12 +2,10 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import { AuthProvider } from './AuthContext';
-import { GlobalStyles } from '@mui/material';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <AuthProvider>
-    <GlobalStyles styles={{ body: { fontSize: '0.875rem' } }} />
     <App />
   </AuthProvider>
 );

--- a/frontend/src/pages/ManageOrganizations.js
+++ b/frontend/src/pages/ManageOrganizations.js
@@ -7,7 +7,7 @@ import api from '../api';
 import { AuthContext } from '../AuthContext';
 
 export default function ManageOrganizations() {
-  const { refreshOrgs } = useContext(AuthContext);
+  const { refreshOrgs, setCurrentOrg } = useContext(AuthContext);
   const [orgs, setOrgs] = useState([]);
   const [newName, setNewName] = useState('');
   const [message, setMessage] = useState({ text: '', error: false });
@@ -51,6 +51,7 @@ export default function ManageOrganizations() {
     await api.delete(`/organizations/${id}`);
     loadOrgs();
     refreshOrgs();
+    setCurrentOrg('');
     setMessage({ text: 'Organization deleted', error: false });
   };
 

--- a/frontend/src/pages/ManageUsers.js
+++ b/frontend/src/pages/ManageUsers.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useMemo, useContext } from 'react';
-import { Box, Typography, Select, MenuItem, Button, Stack, IconButton, Autocomplete, TextField } from '@mui/material';
+import { Box, Typography, Select, MenuItem, Button, Stack, IconButton, Autocomplete, TextField, Avatar } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
 import DeleteIcon from '@mui/icons-material/Delete';
 import { styles } from '../styles';
@@ -69,41 +69,59 @@ export default function ManageUsers() {
     }
   };
 
-  const columns = useMemo(() => [
-    { Header: 'ID', accessor: 'id' },
-    { Header: 'Username', accessor: 'username' },
-    { Header: 'Email', accessor: 'email' },
-    { Header: 'First Name', accessor: 'firstName' },
-    { Header: 'Last Name', accessor: 'lastName' },
-    { Header: 'Balance', accessor: 'balance' },
-    {
-      Header: 'Organizations',
-      accessor: 'organizations',
-      Cell: ({ value }) => value.map(o => o.name).join(', ')
-    },
-    {
-      Header: 'Roles',
-      accessor: 'roles',
-      Cell: ({ row }) => (
-        <Select
-          size="small"
-          multiple
-          value={row.original.roleIds}
-          onChange={e => changeRoles(row.original.id, e.target.value)}
-          renderValue={selected =>
-            roles
-              .filter(r => selected.includes(r.id))
-              .map(r => r.name)
-              .join(', ')
-          }
-        >
-          {roles.map(r => (
-            <MenuItem key={r.id} value={r.id}>{r.name}</MenuItem>
-          ))}
-        </Select>
-      )
-    },
-    {
+  const columns = useMemo(() => {
+    const base = [
+      { Header: 'ID', accessor: 'id' },
+      { Header: 'Username', accessor: 'username' },
+      { Header: 'Email', accessor: 'email' },
+      { Header: 'First Name', accessor: 'firstName' },
+      { Header: 'Last Name', accessor: 'lastName' }
+    ];
+
+    if (!currentOrg) {
+      base.push({
+        Header: 'Profile Picture',
+        accessor: 'profilePicture',
+        Cell: ({ value }) =>
+          value ? <Avatar src={value} sx={{ width: 32, height: 32 }} /> : null
+      });
+      base.push({
+        Header: 'Roles',
+        accessor: 'roles',
+        Cell: ({ value }) => value.join(', ')
+      });
+    } else {
+      base.push({ Header: 'Balance', accessor: 'balance' });
+      base.push({
+        Header: 'Organizations',
+        accessor: 'organizations',
+        Cell: ({ value }) => value.map(o => o.name).join(', ')
+      });
+      base.push({
+        Header: 'Roles',
+        accessor: 'roles',
+        Cell: ({ row }) => (
+          <Select
+            size="small"
+            multiple
+            value={row.original.roleIds}
+            onChange={e => changeRoles(row.original.id, e.target.value)}
+            renderValue={selected =>
+              roles
+                .filter(r => selected.includes(r.id))
+                .map(r => r.name)
+                .join(', ')
+            }
+          >
+            {roles.map(r => (
+              <MenuItem key={r.id} value={r.id}>{r.name}</MenuItem>
+            ))}
+          </Select>
+        )
+      });
+    }
+
+    base.push({
       Header: 'Actions',
       accessor: 'actions',
       Cell: ({ row }) => (
@@ -111,8 +129,10 @@ export default function ManageUsers() {
           <DeleteIcon />
         </IconButton>
       )
-    }
-  ], [users, roles]);
+    });
+
+    return base;
+  }, [users, roles, currentOrg]);
 
   const filtered = useMemo(
     () =>

--- a/frontend/src/styles.js
+++ b/frontend/src/styles.js
@@ -4,8 +4,7 @@ export const styles = {
   root: {
     display: 'grid',
     gridTemplateColumns: `${drawerWidth}px 1fr`,
-    minHeight: '100vh',
-    fontSize: '0.875rem'
+    minHeight: '100vh'
   },
   appBar: {
     zIndex: (theme) => theme.zIndex.drawer + 1,

--- a/index.js
+++ b/index.js
@@ -478,6 +478,7 @@ apiRouter.get('/users', authenticateToken, requireAdmin, async (req, res) => {
       email: u.email,
       firstName: u.firstName,
       lastName: u.lastName,
+      profilePicture: u.profilePicture,
       balance: orgId ? (u.balances.find(b => b.orgId.toString() === orgId)?.amount || 0) : 0,
       organizations: u.organizations.map(o => ({ id: o._id, name: o.name })),
       roleIds: u.roles.map(r => r._id),


### PR DESCRIPTION
## Summary
- remove global styles from React entry
- reset layout sizing in `styles.js`
- add Reset Password link to drawer
- give navigation icons 16px spacing
- clear selected organization after deletion
- tweak Manage Users table for unassigned users
- expose user profile pictures in API

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686366dc5fa8832687fbe2e206e11746