### PR TITLE
Adjust root layout and cell padding

### DIFF
--- a/frontend/src/styles.js
+++ b/frontend/src/styles.js
@@ -2,8 +2,7 @@ export const drawerWidth = 240;
 
 export const styles = {
   root: {
-    gridTemplateColumns: `${drawerWidth}px 1fr`,
-    minHeight: '100vh'
+    display: 'flex'
   },
   appBar: {
     zIndex: (theme) => theme.zIndex.drawer + 1,
@@ -25,7 +24,7 @@ export const styles = {
     borderCollapse: 'collapse',
     '& th, & td': {
       textAlign: 'left',
-      padding: '6px'
+      padding: '8px'
     },
     '& th': { borderBottom: '1px solid', borderColor: 'divider' }
   },


### PR DESCRIPTION
## Summary
- change root layout from grid to flex
- adjust padding for table headers and cells

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68636feb019083269baa08ea41cb2e05