### PR TITLE
Fix /users filtering by organization

### DIFF
--- a/index.js
+++ b/index.js
@@ -468,7 +468,8 @@ apiRouter.patch('/organizations/:id', authenticateToken, requireSuperAdmin, asyn
 
 apiRouter.get('/users', authenticateToken, requireAdmin, async (req, res) => {
   const { orgId } = req.query;
-  const users = await User.find()
+  const filter = orgId ? { organizations: orgId } : {};
+  const users = await User.find(filter)
     .populate('roles', 'code name')
     .populate('organizations', 'name');
   res.json(


### PR DESCRIPTION
## Summary
- filter users by `orgId` in `/users`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6863752c105c8326b79bd4a15375e128