### PR TITLE
Fix role code naming for admin pages

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -71,10 +71,9 @@ export default function App() {
   ];
   const adminNav = { text: 'Administration', path: '/admin', icon: <AdminPanelSettings /> };
   const showAdminNav =
-    profile && isAdmin && (
-      (profile.isSuperAdmin && !currentOrg) ||
-      (!profile.isSuperAdmin && currentOrg)
-    );
+    profile &&
+    isAdmin &&
+    (profile.isSuperAdmin || currentOrg);
   const navItems = token
     ? [...loggedInNav, ...(showAdminNav ? [adminNav] : [])]
     : loggedOutNav;

--- a/frontend/src/pages/ManageUsers.js
+++ b/frontend/src/pages/ManageUsers.js
@@ -50,7 +50,7 @@ export default function ManageUsers() {
   const changeRoles = async (id, roleIds) => {
     await api.post(`/users/${id}/roles`, { roleIds });
     const roleCodes = roles.filter(r => roleIds.includes(r.id)).map(r => r.code);
-    setUsers(users.map(u => (u.id === id ? { ...u, roleIds, roles: roleCodes } : u)));
+    setUsers(users.map(u => (u.id === id ? { ...u, roleIds, roleCodes } : u)));
   };
 
   const addMember = async () => {
@@ -115,7 +115,7 @@ export default function ManageUsers() {
       });
       base.push({
         Header: 'Roles',
-        accessor: 'roles',
+        accessor: 'roleCodes',
         Cell: ({ row }) => (
           <Select
             size="small"
@@ -160,7 +160,14 @@ export default function ManageUsers() {
   );
   const table = useTable({ columns, data: filtered });
 
-  const addOptions = useMemo(() => allUsers, [allUsers]);
+  const addOptions = useMemo(() => {
+    const orgId = currentOrg || addOrgId;
+    if (!orgId) return allUsers;
+    const memberIds = users
+      .filter(u => u.organizations.some(o => o.id === orgId))
+      .map(u => u.id);
+    return allUsers.filter(u => !memberIds.includes(u.id));
+  }, [allUsers, users, currentOrg, addOrgId]);
 
   const removeOptions = useMemo(
     () =>

--- a/index.js
+++ b/index.js
@@ -495,7 +495,7 @@ apiRouter.get('/users', authenticateToken, requireAdmin, async (req, res) => {
       balance: orgId ? (u.balances.find(b => b.orgId.toString() === orgId)?.amount || 0) : 0,
       organizations: u.organizations.map(o => ({ id: o._id, name: o.name })),
       roleIds: u.roles.map(r => r._id),
-      roles: u.roles.map(r => r.code)
+      roleCodes: u.roles.map(r => r.code)
     }))
   );
 });


### PR DESCRIPTION
## Summary
- rename `roles` field from `/users` API to `roleCodes`
- use `roleCodes` when updating roles in the Manage Users table
- show Admin link when super admin selects an organization
- filter Add Member dropdown to exclude existing members

## Testing
- `node --check index.js`

------
https://chatgpt.com/codex/tasks/task_e_6863974331308326bfac8e71d0e9c10d