### PR TITLE
Make tables scrollable with fixed forms

### DIFF
--- a/frontend/src/pages/ManageInvites.js
+++ b/frontend/src/pages/ManageInvites.js
@@ -79,8 +79,33 @@ export default function ManageInvites() {
   const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } = table;
 
   return (
-    <Box>
+    <Box sx={{ display: 'flex', flexDirection: 'column', flexGrow: 1 }}>
       <Typography variant="h6" gutterBottom>Manage Invites</Typography>
+      <Box sx={styles.tableContainer}>
+        <Box component="table" {...getTableProps()} sx={styles.table}>
+          <Box component="thead">
+            {headerGroups.map(hg => (
+              <Box component="tr" {...hg.getHeaderGroupProps()}>
+                {hg.headers.map(col => (
+                  <Box component="th" {...col.getHeaderProps()}>{col.render('Header')}</Box>
+                ))}
+              </Box>
+            ))}
+          </Box>
+          <Box component="tbody" {...getTableBodyProps()}>
+            {rows.map(row => {
+              prepareRow(row);
+              return (
+                <Box component="tr" {...row.getRowProps()}>
+                  {row.cells.map(cell => (
+                    <Box component="td" {...cell.getCellProps()}>{cell.render('Cell')}</Box>
+                  ))}
+                </Box>
+              );
+            })}
+          </Box>
+        </Box>
+      </Box>
       <Box sx={styles.actionRow}>
         <Box component="form" onSubmit={sendInvite} noValidate>
           <Stack direction="row" spacing={1}>
@@ -103,29 +128,6 @@ export default function ManageInvites() {
             </Select>
             <Button type="submit" variant="contained">Invite User</Button>
           </Stack>
-        </Box>
-      </Box>
-      <Box component="table" {...getTableProps()} sx={styles.table}>
-        <Box component="thead">
-          {headerGroups.map(hg => (
-            <Box component="tr" {...hg.getHeaderGroupProps()}>
-              {hg.headers.map(col => (
-                <Box component="th" {...col.getHeaderProps()}>{col.render('Header')}</Box>
-              ))}
-            </Box>
-          ))}
-        </Box>
-        <Box component="tbody" {...getTableBodyProps()}>
-          {rows.map(row => {
-            prepareRow(row);
-            return (
-              <Box component="tr" {...row.getRowProps()}>
-                {row.cells.map(cell => (
-                  <Box component="td" {...cell.getCellProps()}>{cell.render('Cell')}</Box>
-                ))}
-              </Box>
-            );
-          })}
         </Box>
       </Box>
     </Box>

--- a/frontend/src/pages/ManageOrganizations.js
+++ b/frontend/src/pages/ManageOrganizations.js
@@ -97,8 +97,33 @@ export default function ManageOrganizations() {
   const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } = table;
 
   return (
-    <Box>
+    <Box sx={{ display: 'flex', flexDirection: 'column', flexGrow: 1 }}>
       <Typography variant="h6" gutterBottom>Manage Organizations</Typography>
+      <Box sx={styles.tableContainer}>
+        <Box component="table" {...getTableProps()} sx={styles.table}>
+          <Box component="thead">
+            {headerGroups.map(hg => (
+              <Box component="tr" {...hg.getHeaderGroupProps()}>
+                {hg.headers.map(col => (
+                  <Box component="th" {...col.getHeaderProps()}>{col.render('Header')}</Box>
+                ))}
+              </Box>
+            ))}
+          </Box>
+          <Box component="tbody" {...getTableBodyProps()}>
+            {rows.map(row => {
+              prepareRow(row);
+              return (
+                <Box component="tr" {...row.getRowProps()}>
+                  {row.cells.map(cell => (
+                    <Box component="td" {...cell.getCellProps()}>{cell.render('Cell')}</Box>
+                  ))}
+                </Box>
+              );
+            })}
+          </Box>
+        </Box>
+      </Box>
       <Box sx={styles.actionRow}>
         <Box component="form" onSubmit={createOrg}>
           <Stack direction="row" spacing={1}>
@@ -111,29 +136,6 @@ export default function ManageOrganizations() {
             />
             <Button type="submit" variant="contained">Create Organization</Button>
           </Stack>
-        </Box>
-      </Box>
-      <Box component="table" {...getTableProps()} sx={styles.table}>
-        <Box component="thead">
-          {headerGroups.map(hg => (
-            <Box component="tr" {...hg.getHeaderGroupProps()}>
-              {hg.headers.map(col => (
-                <Box component="th" {...col.getHeaderProps()}>{col.render('Header')}</Box>
-              ))}
-            </Box>
-          ))}
-        </Box>
-        <Box component="tbody" {...getTableBodyProps()}>
-          {rows.map(row => {
-            prepareRow(row);
-            return (
-              <Box component="tr" {...row.getRowProps()}>
-                {row.cells.map(cell => (
-                  <Box component="td" {...cell.getCellProps()}>{cell.render('Cell')}</Box>
-                ))}
-              </Box>
-            );
-          })}
         </Box>
       </Box>
     </Box>

--- a/frontend/src/pages/ManageRoles.js
+++ b/frontend/src/pages/ManageRoles.js
@@ -100,8 +100,33 @@ export default function ManageRoles() {
   const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } = table;
 
   return (
-    <Box>
+    <Box sx={{ display: 'flex', flexDirection: 'column', flexGrow: 1 }}>
       <Typography variant="h6" gutterBottom>Manage Roles</Typography>
+      <Box sx={styles.tableContainer}>
+        <Box component="table" {...getTableProps()} sx={styles.table}>
+          <Box component="thead">
+            {headerGroups.map(hg => (
+              <Box component="tr" {...hg.getHeaderGroupProps()}>
+                {hg.headers.map(col => (
+                  <Box component="th" {...col.getHeaderProps()}>{col.render('Header')}</Box>
+                ))}
+              </Box>
+            ))}
+          </Box>
+          <Box component="tbody" {...getTableBodyProps()}>
+            {rows.map(row => {
+              prepareRow(row);
+              return (
+                <Box component="tr" {...row.getRowProps()}>
+                  {row.cells.map(cell => (
+                    <Box component="td" {...cell.getCellProps()}>{cell.render('Cell')}</Box>
+                  ))}
+                </Box>
+              );
+            })}
+          </Box>
+        </Box>
+      </Box>
       <Box sx={styles.actionRow}>
         <Box component="form" onSubmit={createRole}>
           <TextField
@@ -120,29 +145,6 @@ export default function ManageRoles() {
             onChange={e => setNewName(e.target.value)}
           />
           <Button sx={styles.ml1} type="submit" variant="contained">Add</Button>
-        </Box>
-      </Box>
-      <Box component="table" {...getTableProps()} sx={styles.table}>
-        <Box component="thead">
-          {headerGroups.map(hg => (
-            <Box component="tr" {...hg.getHeaderGroupProps()}>
-              {hg.headers.map(col => (
-                <Box component="th" {...col.getHeaderProps()}>{col.render('Header')}</Box>
-              ))}
-            </Box>
-          ))}
-        </Box>
-        <Box component="tbody" {...getTableBodyProps()}>
-          {rows.map(row => {
-            prepareRow(row);
-            return (
-              <Box component="tr" {...row.getRowProps()}>
-                {row.cells.map(cell => (
-                  <Box component="td" {...cell.getCellProps()}>{cell.render('Cell')}</Box>
-                ))}
-              </Box>
-            );
-          })}
         </Box>
       </Box>
     </Box>

--- a/frontend/src/pages/ManageUsers.js
+++ b/frontend/src/pages/ManageUsers.js
@@ -207,8 +207,33 @@ export default function ManageUsers() {
   } = table;
 
   return (
-    <Box>
+    <Box sx={{ display: 'flex', flexDirection: 'column', flexGrow: 1 }}>
       <Typography variant="h6" gutterBottom>Manage Users</Typography>
+      <Box sx={styles.tableContainer}>
+        <Box component="table" {...getTableProps()} sx={styles.table}>
+          <Box component="thead">
+            {headerGroups.map(hg => (
+              <Box component="tr" {...hg.getHeaderGroupProps()}>
+                {hg.headers.map(col => (
+                  <Box component="th" {...col.getHeaderProps()}>{col.render('Header')}</Box>
+                ))}
+              </Box>
+            ))}
+          </Box>
+          <Box component="tbody" {...getTableBodyProps()}>
+            {rows.map(row => {
+              prepareRow(row);
+              return (
+                <Box component="tr" {...row.getRowProps()}>
+                  {row.cells.map(cell => (
+                    <Box component="td" {...cell.getCellProps()}>{cell.render('Cell')}</Box>
+                  ))}
+                </Box>
+              );
+            })}
+          </Box>
+        </Box>
+      </Box>
       <Box sx={styles.actionRow}>
         {profile?.isSuperAdmin && (
           <Box component="form" onSubmit={addMember}>
@@ -266,30 +291,7 @@ export default function ManageUsers() {
             </Stack>
           </Box>
         )}
-      </Box>
-      <Box component="table" {...getTableProps()} sx={styles.table}>
-        <Box component="thead">
-          {headerGroups.map(hg => (
-            <Box component="tr" {...hg.getHeaderGroupProps()}>
-              {hg.headers.map(col => (
-                <Box component="th" {...col.getHeaderProps()}>{col.render('Header')}</Box>
-              ))}
-            </Box>
-          ))}
-        </Box>
-        <Box component="tbody" {...getTableBodyProps()}>
-          {rows.map(row => {
-            prepareRow(row);
-            return (
-              <Box component="tr" {...row.getRowProps()}>
-                {row.cells.map(cell => (
-                  <Box component="td" {...cell.getCellProps()}>{cell.render('Cell')}</Box>
-                ))}
-              </Box>
-            );
-          })}
         </Box>
       </Box>
-    </Box>
-  );
-}
+    );
+  }

--- a/frontend/src/styles.js
+++ b/frontend/src/styles.js
@@ -2,7 +2,8 @@ export const drawerWidth = 240;
 
 export const styles = {
   root: {
-    display: 'flex'
+    display: 'flex',
+    minHeight: '100vh'
   },
   appBar: {
     zIndex: (theme) => theme.zIndex.drawer + 1,
@@ -17,10 +18,23 @@ export const styles = {
       backgroundColor: '#f7f7f7'
     }
   },
-  content: { flexGrow: 1, p: 3 },
+  content: {
+    flexGrow: 1,
+    p: 3,
+    display: 'flex',
+    flexDirection: 'column',
+    height: '100%'
+  },
+  tableContainer: {
+    flexGrow: 1,
+    overflowY: 'auto',
+    overflowX: 'auto',
+    mt: 2
+  },
   formStack: { maxWidth: 300 },
   table: {
-    width: '100%',
+    width: 'max-content',
+    minWidth: '100%',
     borderCollapse: 'collapse',
     '& th, & td': {
       textAlign: 'left',


### PR DESCRIPTION
## Summary
- add a shared `tableContainer` style with horizontal/vertical scrolling
- let admin tables use the new container and expand beyond 100% width

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68641a88c6d48326ad1a419222e2a5b1