### PR TITLE
Update table layout and role editing

### DIFF
--- a/frontend/src/pages/ManageInvites.js
+++ b/frontend/src/pages/ManageInvites.js
@@ -56,7 +56,6 @@ export default function ManageInvites() {
 
 
   const columns = useMemo(() => [
-    { Header: 'ID', accessor: 'id' },
     { Header: 'Email', accessor: 'email' },
     { Header: 'Token', accessor: 'token' },
     {

--- a/frontend/src/pages/ManageOrganizations.js
+++ b/frontend/src/pages/ManageOrganizations.js
@@ -74,7 +74,6 @@ export default function ManageOrganizations() {
   };
 
   const columns = useMemo(() => [
-    { Header: 'ID', accessor: 'id' },
     {
       Header: 'Name',
       accessor: 'name',

--- a/frontend/src/pages/ManageRoles.js
+++ b/frontend/src/pages/ManageRoles.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useMemo, useContext } from 'react';
-import { Box, Typography, TextField, IconButton, Button } from '@mui/material';
+import { Box, Typography, TextField, IconButton, Button, Stack } from '@mui/material';
 import { styles } from '../styles';
 import DeleteIcon from '@mui/icons-material/Delete';
 import { useTable } from 'react-table';
@@ -59,31 +59,52 @@ export default function ManageRoles() {
     showToast('Role created', 'success');
   };
 
-  const columns = useMemo(() => [
-    { Header: 'ID', accessor: 'id' },
-    {
-      Header: 'Code',
-      accessor: 'code',
-      Cell: ({ row }) => (
+  const CodeCell = ({ row }) => {
+    const [value, setValue] = useState(row.original.code);
+    const save = () => updateRole(row.original.id, 'code', value);
+    const onKeyDown = (e) => { if (e.key === 'Enter') save(); };
+    return (
+      <Stack direction="row" spacing={1}>
         <TextField
           size="small"
           placeholder="Code"
-          value={row.original.code}
-          onChange={e => updateRole(row.original.id, 'code', e.target.value)}
+          value={value}
+          onChange={e => setValue(e.target.value)}
+          onKeyDown={onKeyDown}
         />
-      )
-    },
-    {
-      Header: 'Name',
-      accessor: 'name',
-      Cell: ({ row }) => (
+        <Button size="small" variant="contained" onClick={save}>Change</Button>
+      </Stack>
+    );
+  };
+
+  const NameCell = ({ row }) => {
+    const [value, setValue] = useState(row.original.name);
+    const save = () => updateRole(row.original.id, 'name', value);
+    const onKeyDown = (e) => { if (e.key === 'Enter') save(); };
+    return (
+      <Stack direction="row" spacing={1}>
         <TextField
           size="small"
           placeholder="Name"
-          value={row.original.name}
-          onChange={e => updateRole(row.original.id, 'name', e.target.value)}
+          value={value}
+          onChange={e => setValue(e.target.value)}
+          onKeyDown={onKeyDown}
         />
-      )
+        <Button size="small" variant="contained" onClick={save}>Change</Button>
+      </Stack>
+    );
+  };
+
+  const columns = useMemo(() => [
+    {
+      Header: 'Name',
+      accessor: 'name',
+      Cell: NameCell
+    },
+    {
+      Header: 'Code',
+      accessor: 'code',
+      Cell: CodeCell
     },
     {
       Header: 'Actions',

--- a/frontend/src/pages/ManageUsers.js
+++ b/frontend/src/pages/ManageUsers.js
@@ -112,7 +112,6 @@ export default function ManageUsers() {
 
   const columns = useMemo(() => {
     const base = [
-      { Header: 'ID', accessor: 'id' },
       { Header: 'Username', accessor: 'username' },
       { Header: 'Email', accessor: 'email' },
       { Header: 'First Name', accessor: 'firstName' },

--- a/frontend/src/styles.js
+++ b/frontend/src/styles.js
@@ -40,7 +40,13 @@ export const styles = {
       textAlign: 'left',
       padding: '8px'
     },
-    '& th': { borderBottom: '1px solid', borderColor: 'divider' }
+    '& th': { borderBottom: '1px solid', borderColor: 'divider' },
+    '& th:first-of-type, & td:first-of-type': {
+      position: 'sticky',
+      left: 0,
+      backgroundColor: 'background.paper',
+      zIndex: 1
+    }
   },
   actionRow: { mt: 2 },
   ml1: { ml: 1 },


### PR DESCRIPTION
## Summary
- remove ID column from roles, organizations, invites and users tables
- make first table column sticky so names stay visible when scrolling
- allow changing role name and code via explicit button or pressing Enter

## Testing
- `npm run build` *(fails: Cannot find module 'esbuild')*

------
https://chatgpt.com/codex/tasks/task_e_68641fa5aae88326a447a450787dfc01