### PR TITLE
Update admin content layering and table width

### DIFF
--- a/frontend/src/styles.js
+++ b/frontend/src/styles.js
@@ -30,7 +30,8 @@ export const styles = {
     overflowY: 'auto',
     overflowX: 'auto',
     mt: 2,
-    height: '100%'
+    height: '100%',
+    width: `calc(100vw - ${drawerWidth}px - 48px)`
   },
   formStack: { maxWidth: 300 },
   table: {
@@ -59,7 +60,7 @@ export const styles = {
     borderTop: '1px solid',
     borderColor: 'divider'
   },
-  adminContent: { mt: 2 },
+  adminContent: { mt: 2, zIndex: 1 },
   ml1: { ml: 1 },
   mb2: { mb: 2 },
   mt2: { mt: 2 }


### PR DESCRIPTION
## Summary
- set z-index on admin content for stacking context
- size React tables based on viewport width minus drawer

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68656f7fb5a48326a0aa004be7416adb