### PR TITLE
Improve responsive design

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useContext } from 'react';
+import React, { useEffect, useContext, useState } from 'react';
 import { BrowserRouter as Router, Routes, Route, Link, Navigate } from 'react-router-dom';
 import {
   AppBar,
@@ -16,8 +16,11 @@ import {
   MenuItem,
   FormControl,
   InputLabel,
-  Avatar
+  Avatar,
+  IconButton
 } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
+import useMediaQuery from '@mui/material/useMediaQuery';
 import { API_ROOT } from './api';
 import {
   PersonAdd,
@@ -30,7 +33,8 @@ import {
   AccountBalanceWallet,
   AdminPanelSettings,
   Logout,
-  LockReset
+  LockReset,
+  Menu as MenuIcon
 } from '@mui/icons-material';
 import { styles } from './styles';
 import Register from './pages/Register';
@@ -49,6 +53,9 @@ import LogoutPage from './pages/Logout';
 import { AuthContext } from './AuthContext';
 
 export default function App() {
+  const theme = useTheme();
+  const isSmall = useMediaQuery(theme.breakpoints.down('sm'));
+  const [mobileOpen, setMobileOpen] = useState(false);
   const loggedOutNav = [
     { text: 'Register', path: '/register', icon: <PersonAdd /> },
     { text: 'Login', path: '/login', icon: <LoginIcon /> },
@@ -90,12 +97,25 @@ export default function App() {
     const id = e.target.value;
     setCurrentOrg(id);
   };
+  const handleDrawerToggle = () => {
+    setMobileOpen(!mobileOpen);
+  };
   return (
     <Router>
       <Box sx={styles.root}>
         <CssBaseline />
         <AppBar position="fixed" sx={styles.appBar}>
           <Toolbar>
+            {isSmall && (
+              <IconButton
+                color="inherit"
+                edge="start"
+                onClick={handleDrawerToggle}
+                sx={{ mr: 2 }}
+              >
+                <MenuIcon />
+              </IconButton>
+            )}
             <Typography variant="h6" noWrap component="div" sx={{ flexGrow: 1 }}>
               Dashboard
             </Typography>
@@ -134,7 +154,10 @@ export default function App() {
           </Toolbar>
         </AppBar>
         <Drawer
-          variant="permanent"
+          variant={isSmall ? 'temporary' : 'permanent'}
+          open={isSmall ? mobileOpen : true}
+          onClose={handleDrawerToggle}
+          ModalProps={{ keepMounted: true }}
           sx={styles.drawer}
         >
           <Toolbar />

--- a/frontend/src/pages/ManageInvites.js
+++ b/frontend/src/pages/ManageInvites.js
@@ -102,7 +102,7 @@ export default function ManageInvites() {
       </Box>
       <Box sx={styles.actionRow}>
         <Box component="form" onSubmit={sendInvite} noValidate>
-          <Stack direction="row" spacing={1}>
+          <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1}>
             <TextField
               size="small"
               label="Email"
@@ -110,13 +110,14 @@ export default function ManageInvites() {
               type="email"
               value={email}
               onChange={e => setEmail(e.target.value)}
+              sx={{ width: { xs: '100%', sm: 'auto' } }}
             />
             <Select
               size="small"
               value={role}
               onChange={e => setRole(e.target.value)}
               displayEmpty
-              sx={{ width: 160 }}
+              sx={{ width: { xs: '100%', sm: 160 } }}
             >
               <MenuItem value="" disabled>
                 Role

--- a/frontend/src/pages/ManageOrganizations.js
+++ b/frontend/src/pages/ManageOrganizations.js
@@ -61,7 +61,7 @@ export default function ManageOrganizations() {
     const [value, setValue] = useState(row.original.name);
     const save = () => updateName(row.original.id, value);
     return (
-      <Stack direction="row" spacing={1}>
+      <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1}>
         <TextField
           size="small"
           placeholder="Name"
@@ -125,7 +125,7 @@ export default function ManageOrganizations() {
       </Box>
       <Box sx={styles.actionRow}>
         <Box component="form" onSubmit={createOrg}>
-          <Stack direction="row" spacing={1}>
+          <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1}>
             <TextField
               size="small"
               label="Name"

--- a/frontend/src/pages/ManageRoles.js
+++ b/frontend/src/pages/ManageRoles.js
@@ -64,7 +64,7 @@ export default function ManageRoles() {
     const save = () => updateRole(row.original.id, 'code', value);
     const onKeyDown = (e) => { if (e.key === 'Enter') save(); };
     return (
-      <Stack direction="row" spacing={1}>
+      <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1}>
         <TextField
           size="small"
           placeholder="Code"
@@ -82,7 +82,7 @@ export default function ManageRoles() {
     const save = () => updateRole(row.original.id, 'name', value);
     const onKeyDown = (e) => { if (e.key === 'Enter') save(); };
     return (
-      <Stack direction="row" spacing={1}>
+      <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1}>
         <TextField
           size="small"
           placeholder="Name"
@@ -149,7 +149,7 @@ export default function ManageRoles() {
         </Box>
       </Box>
       <Box sx={styles.actionRow}>
-        <Box component="form" onSubmit={createRole}>
+        <Stack component="form" onSubmit={createRole} direction={{ xs: 'column', sm: 'row' }} spacing={1}>
           <TextField
             label="Name"
             placeholder="Name"
@@ -161,12 +161,11 @@ export default function ManageRoles() {
             label="Code"
             placeholder="Code"
             size="small"
-            sx={styles.ml1}
             value={newCode}
             onChange={e => setNewCode(e.target.value)}
           />
-          <Button sx={styles.ml1} type="submit" variant="contained">Add</Button>
-        </Box>
+          <Button type="submit" variant="contained">Add</Button>
+        </Stack>
       </Box>
     </Box>
   );

--- a/frontend/src/pages/ManageUsers.js
+++ b/frontend/src/pages/ManageUsers.js
@@ -222,13 +222,13 @@ export default function ManageUsers() {
       <Box sx={styles.actionRow}>
         {profile?.isSuperAdmin && (
           <Box component="form" onSubmit={addMember}>
-            <Stack direction="row" spacing={1}>
+            <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1}>
               <Autocomplete
                 options={addOptions}
                 getOptionLabel={u => u.username || ''}
                 onChange={(_, v) => setAddUserId(v ? v.id : '')}
                 renderInput={params => <TextField {...params} size="small" label="User" />}
-                sx={{ width: 200 }}
+                sx={{ width: { xs: '100%', sm: 200 } }}
               />
               {!currentOrg && (
                 <Autocomplete
@@ -239,7 +239,7 @@ export default function ManageUsers() {
                     setAddRoleId('');
                   }}
                   renderInput={params => <TextField {...params} size="small" label="Organization" />}
-                  sx={{ width: 200 }}
+                  sx={{ width: { xs: '100%', sm: 200 } }}
                 />
               )}
               <Select
@@ -247,7 +247,7 @@ export default function ManageUsers() {
                 value={addRoleId}
                 onChange={e => setAddRoleId(e.target.value)}
                 displayEmpty
-                sx={{ width: 160 }}
+                sx={{ width: { xs: '100%', sm: 160 } }}
               >
                 <MenuItem value="" disabled>
                   Role
@@ -264,13 +264,13 @@ export default function ManageUsers() {
         )}
         {currentOrg && (
           <Box component="form" onSubmit={removeMember} sx={{ mt: 2 }}>
-            <Stack direction="row" spacing={1}>
+            <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1}>
               <Autocomplete
                 options={removeOptions}
                 getOptionLabel={u => u.username || ''}
                 onChange={(_, v) => setRemoveUserId(v ? v.id : '')}
                 renderInput={params => <TextField {...params} size="small" label="User" />}
-                sx={{ width: 200 }}
+                sx={{ width: { xs: '100%', sm: 200 } }}
               />
               <Button type="submit" variant="contained" color="error">Remove Member</Button>
             </Stack>

--- a/frontend/src/styles.js
+++ b/frontend/src/styles.js
@@ -20,7 +20,7 @@ export const styles = {
   },
   content: {
     flexGrow: 1,
-    p: 3,
+    p: { xs: 1, sm: 3 },
     display: 'flex',
     flexDirection: 'column',
     height: '100%'
@@ -31,14 +31,14 @@ export const styles = {
     overflowX: 'auto',
     mt: 2,
     height: '100%',
-    width: `calc(100vw - ${drawerWidth}px - 48px)`,
+    width: { xs: '100%', sm: `calc(100vw - ${drawerWidth}px - 48px)` },
     border: '1px solid',
     borderColor: 'divider',
     borderRadius: 1,
     backgroundColor: 'background.paper',
     boxShadow: 1
   },
-  formStack: { maxWidth: 300 },
+  formStack: { maxWidth: 300, width: '100%' },
   table: {
     width: '100%',
     height: '100%',
@@ -71,7 +71,7 @@ export const styles = {
   actionRow: {
     position: 'fixed',
     bottom: 0,
-    left: drawerWidth,
+    left: { xs: 0, sm: drawerWidth },
     right: 0,
     p: 2,
     backgroundColor: 'background.paper',


### PR DESCRIPTION
## Summary
- add responsive drawer and mobile menu
- make table and form stacks responsive
- tweak spacing and widths for small screens
- update layout styles for small screens

## Testing
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686573491dd48326a64378d888b0fa7e