### PR TITLE
Improve responsiveness

### DIFF
--- a/frontend/src/pages/AcceptInvite.js
+++ b/frontend/src/pages/AcceptInvite.js
@@ -60,30 +60,32 @@ export default function AcceptInvite() {
   return (
     <Box>
       <Typography variant="h6" gutterBottom>Accept Invites</Typography>
-      <Box component="table" {...getTableProps()} sx={styles.table}>
-        <Box component="thead">
-          {headerGroups.map(hg => (
-            <Box component="tr" {...hg.getHeaderGroupProps()}>
-              {hg.headers.map(col => (
-                <Box component="th" {...col.getHeaderProps()}>{col.render('Header')}</Box>
-              ))}
-            </Box>
-          ))}
-        </Box>
-        <Box component="tbody" {...getTableBodyProps()}>
-          {rows.map(row => {
-            prepareRow(row);
-            return (
-              <Box component="tr" {...row.getRowProps()}>
-                {row.cells.map(cell => (
-                  <Box component="td" {...cell.getCellProps()}>{cell.render('Cell')}</Box>
+      <Box sx={styles.tableContainer}>
+        <Box component="table" {...getTableProps()} sx={styles.table}>
+          <Box component="thead">
+            {headerGroups.map(hg => (
+              <Box component="tr" {...hg.getHeaderGroupProps()}>
+                {hg.headers.map(col => (
+                  <Box component="th" {...col.getHeaderProps()}>{col.render('Header')}</Box>
                 ))}
               </Box>
-            );
-          })}
+            ))}
+          </Box>
+          <Box component="tbody" {...getTableBodyProps()}>
+            {rows.map(row => {
+              prepareRow(row);
+              return (
+                <Box component="tr" {...row.getRowProps()}>
+                  {row.cells.map(cell => (
+                    <Box component="td" {...cell.getCellProps()}>{cell.render('Cell')}</Box>
+                  ))}
+                </Box>
+              );
+            })}
+          </Box>
         </Box>
       </Box>
-      
+
     </Box>
   );
 }

--- a/frontend/src/styles.js
+++ b/frontend/src/styles.js
@@ -20,7 +20,7 @@ export const styles = {
   },
   content: {
     flexGrow: 1,
-    p: { xs: 1, sm: 3 },
+    p: { xs: 1, sm: 2, md: 3, lg: 4, xl: 6 },
     display: 'flex',
     flexDirection: 'column',
     height: '100%'
@@ -31,14 +31,24 @@ export const styles = {
     overflowX: 'auto',
     mt: 2,
     height: '100%',
-    width: { xs: '100%', sm: `calc(100vw - ${drawerWidth}px - 48px)` },
+    width: {
+      xs: '100%',
+      sm: `calc(100vw - ${drawerWidth}px - 48px)`,
+      md: `calc(100vw - ${drawerWidth}px - 48px)`,
+      lg: `calc(100vw - ${drawerWidth}px - 48px)`,
+      xl: `calc(100vw - ${drawerWidth}px - 48px)`
+    },
     border: '1px solid',
     borderColor: 'divider',
     borderRadius: 1,
     backgroundColor: 'background.paper',
     boxShadow: 1
   },
-  formStack: { maxWidth: 300, width: '100%' },
+  formStack: {
+    maxWidth: { xs: '100%', sm: 300, md: 400, lg: 500, xl: 600 },
+    width: '100%',
+    mx: 'auto'
+  },
   table: {
     width: '100%',
     height: '100%',


### PR DESCRIPTION
## Summary
- tune layout padding for medium/large screens
- expand table container to handle all breakpoints
- allow larger form widths for bigger displays
- wrap AcceptInvite table in scrollable container

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68657514ad2c8326b639cd09074712ef