### PR TITLE
Update fonts and tables

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -5,7 +5,7 @@
   <title>Dashboard</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;700&family=Lora:wght@400;500;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;700&display=swap" rel="stylesheet">
 </head>
 <body>
   <div id="root"></div>

--- a/frontend/src/styles.js
+++ b/frontend/src/styles.js
@@ -40,13 +40,7 @@ export const styles = {
     overflowX: 'auto',
     mt: 2,
     height: '100%',
-    width: {
-      xs: '100%',
-      sm: `calc(100vw - ${drawerWidth}px - 48px)`,
-      md: `calc(100vw - ${drawerWidth}px - 48px)`,
-      lg: `calc(100vw - ${drawerWidth}px - 48px)`,
-      xl: `calc(100vw - ${drawerWidth}px - 48px)`
-    },
+    width: '100%',
     border: '1px solid',
     borderColor: 'divider',
     borderRadius: 1,

--- a/frontend/src/theme.js
+++ b/frontend/src/theme.js
@@ -3,7 +3,7 @@ import { grey } from '@mui/material/colors';
 
 export const fonts = {
   body: `'Inter', sans-serif`,
-  heading: `'Lora', serif`
+  heading: `'Inter', sans-serif`
 };
 
 const theme = createTheme({
@@ -46,6 +46,15 @@ const theme = createTheme({
           '::placeholder': {
             color: grey[500],
             opacity: 1
+          }
+        }
+      }
+    },
+    MuiCardContent: {
+      styleOverrides: {
+        root: {
+          '&:last-child': {
+            paddingBottom: '16px'
           }
         }
       }


### PR DESCRIPTION
## Summary
- use Inter for heading text
- make table containers full width
- override CardContent theme to remove extra bottom padding

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6865822daad48326ac6b948b764196e2