### PR TITLE
Adjust main width and profile typography

### DIFF
--- a/frontend/src/pages/Profile.js
+++ b/frontend/src/pages/Profile.js
@@ -77,7 +77,7 @@ export default function Profile() {
                   <Grid item xs={12} sm={6} key={o.id}>
                     <Card variant="outlined">
                       <CardContent>
-                        <Typography>{o.name}</Typography>
+                        <Typography variant="subtitle2">{o.name}</Typography>
                       </CardContent>
                     </Card>
                   </Grid>

--- a/frontend/src/styles.js
+++ b/frontend/src/styles.js
@@ -26,13 +26,7 @@ export const styles = {
     display: 'flex',
     flexDirection: 'column',
     height: '100%',
-    maxWidth: {
-      xs: '100%',
-      sm: `calc(100vw - ${drawerWidth}px - 32px)`,
-      md: `calc(100vw - ${drawerWidth}px - 48px)`,
-      lg: `calc(100vw - ${drawerWidth}px - 64px)`,
-      xl: `calc(100vw - ${drawerWidth}px - 96px)`
-    }
+    maxWidth: `calc(100vw - ${drawerWidth}px)`
   },
   tableContainer: {
     flexGrow: 1,


### PR DESCRIPTION
## Summary
- set main content width based on drawer width
- unify font style for organization cards on profile page

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68658510f9048326955c6fb3a1e085fc