### PR TITLE
Adjust main width when drawer closed

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -35,7 +35,7 @@ import {
   LockReset,
   Menu as MenuIcon
 } from '@mui/icons-material';
-import { styles } from './styles';
+import { styles, drawerWidth } from './styles';
 import Register from './pages/Register';
 import Login from './pages/Login';
 import CreateSuperAdmin from './pages/CreateSuperAdmin';
@@ -100,6 +100,10 @@ export default function App() {
   const handleDrawerToggle = () => {
     setMobileOpen(!mobileOpen);
   };
+  const drawerOpen = isSmall ? mobileOpen : true;
+  const mainMaxWidth = drawerOpen
+    ? `calc(100vw - ${drawerWidth}px)`
+    : '100vw';
   return (
     <Box sx={styles.root}>
         <AppBar position="fixed" sx={styles.appBar}>
@@ -167,7 +171,7 @@ export default function App() {
             ))}
           </List>
         </Drawer>
-        <Box component="main" sx={styles.content}>
+        <Box component="main" sx={{ ...styles.content, maxWidth: mainMaxWidth }}>
           <Toolbar />
           <Routes>
             <Route path="/register" element={<Register />} />

--- a/frontend/src/styles.js
+++ b/frontend/src/styles.js
@@ -25,8 +25,7 @@ export const styles = {
     p: { xs: 1, sm: 2, md: 3, lg: 4, xl: 6 },
     display: 'flex',
     flexDirection: 'column',
-    height: '100%',
-    maxWidth: `calc(100vw - ${drawerWidth}px)`
+    height: '100%'
   },
   tableContainer: {
     flexGrow: 1,


### PR DESCRIPTION
## Summary
- remove fixed maxWidth from styles
- compute max width for main element based on drawer state

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686586346d148326ad067045692aff0f