### PR TITLE
Update main content width logic

### DIFF
--- a/frontend/src/styles.js
+++ b/frontend/src/styles.js
@@ -26,7 +26,7 @@ export const styles = {
     display: 'flex',
     flexDirection: 'column',
     height: '100%',
-    maxWidth: `calc(100vw - ${drawerWidth}px)`
+    maxWidth: { sm: `calc(100vw - ${drawerWidth}px)` }
   },
   tableContainer: {
     flexGrow: 1,


### PR DESCRIPTION
## Summary
- keep the drawer fixed width constant
- set main area max-width only on screens `sm` and up

## Testing
- `node -e "require('./frontend/src/styles.js')"`

------
https://chatgpt.com/codex/tasks/task_e_686588af2a748326b782c0167563b935