### PR TITLE
Update main max width responsiveness

### DIFF
--- a/frontend/src/styles.js
+++ b/frontend/src/styles.js
@@ -26,7 +26,7 @@ export const styles = {
     display: 'flex',
     flexDirection: 'column',
     height: '100%',
-    maxWidth: { xs: '100vw', sm: '100vw', md: `calc(100vw - ${drawerWidth}px)` }
+    maxWidth: { xs: '100vw', sm: `calc(100vw - ${drawerWidth}px)` }
   },
   tableContainer: {
     flexGrow: 1,


### PR DESCRIPTION
## Summary
- adjust the main element maxWidth breakpoint so that small screens and up account for the drawer width

## Testing
- `npx --yes webpack`

------
https://chatgpt.com/codex/tasks/task_e_68658bb403b48326913ff0d44effd2d7