### PR TITLE
Add upload size env var

### DIFF
--- a/.env
+++ b/.env
@@ -3,3 +3,4 @@ MONGO_URI=mongodb+srv://peuan:G6SBejkeJCRWvlBq@songdeegps.btc1g.mongodb.net/song
 JWT_SECRET=supersecretkey
 API_URL=http://localhost:3000/api
 FRONTEND_PORT=4000
+MAX_FILE_SIZE=26214400

--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,4 @@ MONGO_URI=mongodb://localhost:27017/authdb
 JWT_SECRET=supersecretkey
 API_URL=http://localhost:3000/api
 FRONTEND_PORT=4000
+MAX_FILE_SIZE=26214400

--- a/README.md
+++ b/README.md
@@ -41,12 +41,15 @@ MONGO_URI=mongodb://localhost:27017/authdb
 JWT_SECRET=supersecretkey
 API_URL=http://localhost:3000/api
 FRONTEND_PORT=4000
+MAX_FILE_SIZE=26214400
 ```
 
 Copy this file to `.env` and modify values as needed.
 
 The frontend will be available on `FRONTEND_PORT`. It includes simple pages for each API endpoint under `src/index.js`, allowing you to register, log in, manage organizations and members, handle invites, transfer currency and update user roles.
 All API requests use an Axios instance defined in `src/api.js`. The authentication token is stored using React Context in `src/AuthContext.js`, which automatically adds the `Authorization` header for requests. Login now also returns a long-lived refresh token which the Axios wrapper uses to obtain a new access token when a request returns `401`. Profile updates now support uploading a picture and accepting an invite requires providing the invite's token.
+Profile pictures must be JPEG or PNG images and may not exceed 25MB in size.
+The limit can be adjusted with the `MAX_FILE_SIZE` environment variable.
 The UI uses Material UI components with an AppBar and side navigation drawer for a simple dashboard layout. When logged in, a dropdown in the header lists your organizations and the selection is stored only in the browser. Admin features live under an **Administration** page where tables built with `react-table` let you manage users, roles, organizations and invites inline. Super admins may access this page even without belonging to an organization or having roles assigned. Deleting an organization now also removes its roles, invites and any references from user documents.
 
 ## Docker


### PR DESCRIPTION
## Summary
- make max upload file size configurable via `MAX_FILE_SIZE`
- set default upload limit to 25MB
- show max file size error with limit in message
- document variable in README and env files

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686bff84b1008326be3a2bbe2b02efff