### PR TITLE
Add helper functions for secure reset tokens

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ import express from 'express';
 import mongoose from 'mongoose';
 import cors from 'cors';
 import bcrypt from 'bcrypt';
+import crypto from 'crypto';
 import jwt from 'jsonwebtoken';
 import dotenv from 'dotenv';
 import multer from 'multer';
@@ -20,6 +21,17 @@ app.use('/dist', express.static(path.join(__dirname, 'frontend/dist')));
 app.use(express.static(path.join(__dirname, 'frontend/public')));
 app.use('/uploads', express.static(path.join(__dirname, 'uploads')));
 const SECRET = process.env.JWT_SECRET || 'supersecretkey';
+
+const RESET_TOKEN_EXPIRY_MS = 60 * 60 * 1000;
+
+function hashToken(token) {
+  return crypto.createHash('sha256').update(token).digest('hex');
+}
+
+function generateResetToken() {
+  const token = crypto.randomBytes(32).toString('hex');
+  return { token, hash: hashToken(token) };
+}
 
 const ROLE_CODES = {
   ADMIN: 'ADMIN',
@@ -57,7 +69,8 @@ const userSchema = new Schema({
   roles: [{ type: Schema.Types.ObjectId, ref: 'Role' }],
   isSuperAdmin: { type: Boolean, default: false },
   refreshToken: String,
-  resetToken: String
+  resetToken: String,
+  resetTokenExpires: Date
 });
 
 const organizationSchema = new Schema({
@@ -379,18 +392,23 @@ apiRouter.post('/password/forgot', async (req, res) => {
   const trimmed = username ? username.trim() : '';
   const user = await User.findOne({ username: trimmed });
   if (!user) return res.status(404).json({ message: 'User not found' });
-  const token = Math.random().toString(36).substring(2);
-  user.resetToken = token;
+  const { token, hash } = generateResetToken();
+  user.resetToken = hash;
+  user.resetTokenExpires = new Date(Date.now() + RESET_TOKEN_EXPIRY_MS);
   await user.save();
   res.json({ message: 'Reset token created', token });
 });
 
 apiRouter.post('/password/reset', async (req, res) => {
   const { token, newPassword } = req.body;
-  const user = await User.findOne({ resetToken: token });
-  if (!user) return res.status(400).json({ message: 'Invalid token' });
+  const hashedToken = hashToken(token);
+  const user = await User.findOne({ resetToken: hashedToken });
+  if (!user || !user.resetTokenExpires || user.resetTokenExpires < new Date()) {
+    return res.status(400).json({ message: 'Invalid token' });
+  }
   user.passwordHash = await bcrypt.hash(newPassword, 10);
-  user.resetToken = '';
+  user.resetToken = undefined;
+  user.resetTokenExpires = undefined;
   await user.save();
   res.json({ message: 'Password reset' });
 });


### PR DESCRIPTION
## Summary
- refactor password reset logic with helper functions
- move token expiry duration into a constant
- use `generateResetToken` and `hashToken` helpers in routes

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686bff80f17c8326872dbbf1218075da