### PR TITLE
Enforce password policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ FRONTEND_PORT=4000
 
 Copy this file to `.env` and modify values as needed.
 
+## Password Requirements
+
+Passwords must be at least 8 characters long and include both letters and
+numbers. Attempts to register or change a password that does not meet this
+policy will result in a `400` response describing the issue.
+
 The frontend will be available on `FRONTEND_PORT`. It includes simple pages for each API endpoint under `src/index.js`, allowing you to register, log in, manage organizations and members, handle invites, transfer currency and update user roles.
 All API requests use an Axios instance defined in `src/api.js`. The authentication token is stored using React Context in `src/AuthContext.js`, which automatically adds the `Authorization` header for requests. Login now also returns a long-lived refresh token which the Axios wrapper uses to obtain a new access token when a request returns `401`. Profile updates now support uploading a picture and accepting an invite requires providing the invite's token.
 The UI uses Material UI components with an AppBar and side navigation drawer for a simple dashboard layout. When logged in, a dropdown in the header lists your organizations and the selection is stored only in the browser. Admin features live under an **Administration** page where tables built with `react-table` let you manage users, roles, organizations and invites inline. Super admins may access this page even without belonging to an organization or having roles assigned. Deleting an organization now also removes its roles, invites and any references from user documents.


### PR DESCRIPTION
## Summary
- validate passwords for register and password change endpoints
- document password requirements
- fix duplicated email check during registration
- validate password on superadmin creation

## Testing
- `node --check index.js`


------
https://chatgpt.com/codex/tasks/task_e_686bff8683888326ba9833819f5cea08