### PR TITLE
Improve password reset validation

### DIFF
--- a/index.js
+++ b/index.js
@@ -459,6 +459,12 @@ apiRouter.post('/password/reset', async (req, res) => {
   if (!user || !user.resetTokenExpires || user.resetTokenExpires < new Date()) {
     return res.status(400).json({ message: 'Invalid token' });
   }
+  if (!validatePassword(newPassword)) {
+    return res.status(400).json({
+      message:
+        'Password must be at least 8 characters and contain letters and numbers'
+    });
+  }
   user.passwordHash = await bcrypt.hash(newPassword, 10);
   user.resetToken = undefined;
   user.resetTokenExpires = undefined;


### PR DESCRIPTION
## Summary
- validate new password in the `/password/reset` route
- return HTTP 400 if the new password doesn't meet requirements

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686c04e7984c8326ba7f8a57b4b2eaa5