### PR TITLE
Restrict role management to super admins

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ All API requests use an Axios instance defined in `src/api.js`. The authenticati
 Profile pictures must be JPEG or PNG images and may not exceed 25MB in size.
 The limit can be adjusted with the `MAX_FILE_SIZE` environment variable.
 The UI uses Material UI components with an AppBar and side navigation drawer for a simple dashboard layout. When logged in, a dropdown in the header lists your organizations and the selection is stored only in the browser. Admin features live under an **Administration** page where tables built with `react-table` let you manage users, roles, organizations and invites inline. Super admins may access this page even without belonging to an organization or having roles assigned. Deleting an organization removes its invites and any references from user documents, but roles remain.
+Organization administrators can rename their currently selected organization from the **Org Settings** tab within this Administration section.
 
 ## Docker
 

--- a/frontend/src/pages/Administration.js
+++ b/frontend/src/pages/Administration.js
@@ -14,6 +14,7 @@ export default function Administration() {
   const navigate = useNavigate();
   const [tab, setTab] = useState(0);
   const showOrgs = profile?.isSuperAdmin;
+  const showRoles = profile?.isSuperAdmin;
   useEffect(() => {
     if (isAdmin && !profile?.isSuperAdmin && !currentOrg) {
       navigate('/profile');
@@ -25,7 +26,7 @@ export default function Administration() {
     const label = currentOrg ? 'Users' : 'Unassigned Users';
     tabs.push({ label, component: <ManageUsers /> });
   }
-  if (profile?.isSuperAdmin) tabs.push({ label: 'Roles', component: <ManageRoles /> });
+  if (showRoles) tabs.push({ label: 'Roles', component: <ManageRoles /> });
   if (showOrgs) tabs.push({ label: 'Organizations', component: <ManageOrganizations /> });
   if (currentOrg) {
     tabs.push({ label: 'Invites', component: <ManageInvites /> });

--- a/frontend/src/pages/ManageRoles.js
+++ b/frontend/src/pages/ManageRoles.js
@@ -6,12 +6,16 @@ import { useTable } from 'react-table';
 import api from '../api';
 import { ToastContext } from '../ToastContext';
 import { ApiContext } from '../ApiContext';
+import { AuthContext } from '../AuthContext';
 
 export default function ManageRoles() {
   const { showToast } = useContext(ToastContext);
   const { roles, refreshRoles } = useContext(ApiContext);
+  const { profile } = useContext(AuthContext);
   const [newCode, setNewCode] = useState('');
   const [newName, setNewName] = useState('');
+
+  if (!profile?.isSuperAdmin) return null;
 
   useEffect(() => {
     refreshRoles();


### PR DESCRIPTION
## Summary
- ensure ManageRoles component only renders for super admins
- hide the Roles tab entirely for non-super admins
- note the Org Settings tab in README for renaming an organization

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687fd2b2404c8326bf01af4e98f52ed8