### PR TITLE
Fix missing invite token

### DIFF
--- a/index.js
+++ b/index.js
@@ -620,7 +620,14 @@ apiRouter.get(
   requireOrgAdmin,
   async (req, res) => {
     await req.org.populate('invites');
-    res.json(req.org.invites.map(i => ({ id: i._id, email: i.email, role: i.role })));
+    res.json(
+      req.org.invites.map(i => ({
+        id: i._id,
+        email: i.email,
+        token: i.token,
+        role: i.role
+      }))
+    );
   }
 );
 


### PR DESCRIPTION
## Summary
- include the token when listing invites for an organization so the UI can display it

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688125c0cda08326b0df081b8e99d81f