### PR TITLE
Support unassigned user listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,12 @@ Endpoints include registration, login, profile management, organization manageme
 a listing of your organizations and a simple currency transfer system. All API
 routes are now served under the `/api` prefix (for example `/api/login`).
 Routes that modify organization membership or invites require an admin user. Admins
-can list all users with `GET /users`, change a user's role with `POST /users/:id/role`,
-list all organizations via `GET /organizations/all` and update an organization's name
-using `PATCH /organizations/:id`. Roles themselves are stored in a separate collection
-and can be managed with CRUD endpoints under `/roles`. Admins may also list or delete invites through `/invites`.
+can list organization members with `GET /users?orgId=<org>` or fetch users not
+assigned to any organization with `GET /users`. They may change a user's role with
+`POST /users/:id/role`, list all organizations via `GET /organizations/all` and update
+an organization's name using `PATCH /organizations/:id`. Roles themselves are stored
+in a separate collection and can be managed with CRUD endpoints under `/roles`.
+Admins may also list or delete invites through `/invites`.
 
 When the server is running you can explore all endpoints using Swagger UI at [`/api-docs`](http://localhost:3000/api-docs).
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -457,6 +457,10 @@ paths:
   /users:
     get:
       summary: List users
+      description: |
+        If an `orgId` query parameter is supplied, only members of that
+        organization are returned. When omitted, the response includes
+        users that are not part of any organization.
       parameters:
         - in: query
           name: orgId

--- a/frontend/src/pages/ManageUsers.js
+++ b/frontend/src/pages/ManageUsers.js
@@ -27,10 +27,12 @@ export default function ManageUsers() {
       : Promise.resolve({ data: [] });
     const allReq = currentOrg
       ? api.get('/users', { params: { orgId: currentOrg } })
-      : Promise.resolve({ data: [] });
+      : api.get('/users');
     const [oRes, aRes] = await Promise.all([orgReq, allReq]);
     if (currentOrg) {
       await Promise.all([refreshUsers(currentOrg), refreshRoles(currentOrg)]);
+    } else {
+      await refreshUsers();
     }
     setAllUsers(aRes.data);
     setOrgs(oRes.data.map(o => ({ id: o.id, name: o.name })));

--- a/index.js
+++ b/index.js
@@ -684,6 +684,8 @@ apiRouter.get('/users', authenticateToken, requireOrgAdmin, async (req, res) => 
   let filter = {};
   if (orgId && mongoose.isValidObjectId(orgId)) {
     filter.organizations = new mongoose.Types.ObjectId(orgId);
+  } else if (!orgId) {
+    filter.organizations = { $size: 0 };
   }
   const users = await User.find(filter)
     .populate('roles', 'code name')


### PR DESCRIPTION
## Summary
- return unassigned users when no `orgId` is supplied
- support managing unassigned users on the admin page
- document the new behaviour for `/users` endpoint

## Testing
- `node -c index.js`

------
https://chatgpt.com/codex/tasks/task_e_68813064a1248326bf95eac3f0097c36