### PR TITLE
Add friend management features

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ Admins may also list or delete invites through `/invites`.
 Users can send friend requests by email and accept them to build a list of friends
 for quick transfers. Retrieve pending requests with `GET /friends/requests`, send
 a request using `POST /friends/request` and accept with
-`POST /friends/requests/{id}/accept`. A user's friends are listed via `GET /friends`.
+`POST /friends/requests/{id}/accept`. A user's friends are listed via `GET /friends`
+and can be removed with `DELETE /friends/{id}`.
 
 When the server is running you can explore all endpoints using Swagger UI at [`/api-docs`](http://localhost:3000/api-docs).
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -756,6 +756,22 @@ paths:
                   email: johndoe@example.com
                   firstName: John
                   lastName: Doe
+  /friends/{id}:
+    delete:
+      summary: Remove friend
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Friend removed
+          content:
+            application/json:
+              example:
+                message: Friend removed
   /transfer:
     post:
       summary: Transfer currency

--- a/frontend/src/ApiContext.js
+++ b/frontend/src/ApiContext.js
@@ -63,6 +63,11 @@ export function ApiProvider({ children }) {
     await Promise.all([refreshFriends(), refreshFriendRequests()]);
   };
 
+  const removeFriend = async (id) => {
+    await api.delete(`/friends/${id}`);
+    await refreshFriends();
+  };
+
   const register = async (form) => {
     await api.post('/register', form);
   };
@@ -108,6 +113,7 @@ export function ApiProvider({ children }) {
       refreshFriendRequests,
       sendFriendRequest,
       acceptFriendRequest,
+      removeFriend,
       register,
       changePassword,
       forgotPassword,

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -33,6 +33,7 @@ import {
   AdminPanelSettings,
   Logout,
   LockReset,
+  People,
   Menu as MenuIcon
 } from '@mui/icons-material';
 import { styles } from './styles';
@@ -45,6 +46,7 @@ import ChangePassword from './pages/ChangePassword';
 import AcceptInvite from './pages/AcceptInvite';
 import AddFriend from './pages/AddFriend';
 import AcceptFriend from './pages/AcceptFriend';
+import ManageFriends from './pages/ManageFriends';
 import Transfer from './pages/Transfer';
 import Balance from './pages/Balance';
 import Administration from './pages/Administration';
@@ -73,6 +75,7 @@ export default function App() {
     { text: 'Accept Invite', path: '/accept-invite', icon: <HowToReg /> },
     { text: 'Add Friend', path: '/add-friend', icon: <PersonAdd /> },
     { text: 'Friend Requests', path: '/accept-friend', icon: <HowToReg /> },
+    { text: 'Friends', path: '/manage-friends', icon: <People /> },
     ...(currentOrg ? [
       { text: 'Transfer', path: '/transfer', icon: <SwapHoriz /> },
       { text: 'Balance', path: '/balance', icon: <AccountBalanceWallet /> }
@@ -183,6 +186,7 @@ export default function App() {
             <Route path="/accept-invite" element={<AcceptInvite />} />
             <Route path="/add-friend" element={<AddFriend />} />
             <Route path="/accept-friend" element={<AcceptFriend />} />
+            <Route path="/manage-friends" element={<ManageFriends />} />
             <Route path="/transfer" element={<Transfer />} />
             <Route path="/balance" element={<Balance />} />
             <Route path="/admin" element={<Administration />} />

--- a/frontend/src/pages/ManageFriends.js
+++ b/frontend/src/pages/ManageFriends.js
@@ -1,0 +1,78 @@
+import React, { useEffect, useContext, useMemo } from 'react';
+import { Box, IconButton } from '@mui/material';
+import DeleteIcon from '@mui/icons-material/Delete';
+import { useTable } from 'react-table';
+import { ApiContext } from '../ApiContext';
+import { ToastContext } from '../ToastContext';
+import { styles } from '../styles';
+
+export default function ManageFriends() {
+  const { friends, refreshFriends, removeFriend } = useContext(ApiContext);
+  const { showToast } = useContext(ToastContext);
+
+  useEffect(() => {
+    refreshFriends();
+  }, [refreshFriends]);
+
+  const del = async (id) => {
+    if (!window.confirm('Remove this friend?')) return;
+    try {
+      await removeFriend(id);
+      showToast('Friend removed', 'success');
+    } catch (err) {
+      showToast(err.response?.data?.message || 'Error removing friend', 'error');
+    }
+  };
+
+  const columns = useMemo(
+    () => [
+      { Header: 'Username', accessor: 'username' },
+      { Header: 'Email', accessor: 'email' },
+      { Header: 'First Name', accessor: 'firstName' },
+      { Header: 'Last Name', accessor: 'lastName' },
+      {
+        Header: 'Actions',
+        accessor: 'actions',
+        Cell: ({ row }) => (
+          <IconButton color="error" onClick={() => del(row.original.id)}>
+            <DeleteIcon />
+          </IconButton>
+        )
+      }
+    ],
+    [friends]
+  );
+
+  const table = useTable({ columns, data: friends });
+  const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } = table;
+
+  return (
+    <Box>
+      <Box sx={styles.tableContainer}>
+        <Box component="table" {...getTableProps()} sx={styles.table}>
+          <Box component="thead">
+            {headerGroups.map(hg => (
+              <Box component="tr" {...hg.getHeaderGroupProps()}>
+                {hg.headers.map(col => (
+                  <Box component="th" {...col.getHeaderProps()}>{col.render('Header')}</Box>
+                ))}
+              </Box>
+            ))}
+          </Box>
+          <Box component="tbody" {...getTableBodyProps()}>
+            {rows.map(row => {
+              prepareRow(row);
+              return (
+                <Box component="tr" {...row.getRowProps()}>
+                  {row.cells.map(cell => (
+                    <Box component="td" {...cell.getCellProps()}>{cell.render('Cell')}</Box>
+                  ))}
+                </Box>
+              );
+            })}
+          </Box>
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/index.js
+++ b/index.js
@@ -911,6 +911,20 @@ apiRouter.get('/friends', authenticateToken, async (req, res) => {
   );
 });
 
+apiRouter.delete('/friends/:id', authenticateToken, async (req, res) => {
+  const { id } = req.params;
+  const user = await User.findById(req.user.id);
+  if (!user.friends.includes(id)) {
+    return res.status(404).json({ message: 'Friend not found' });
+  }
+  const friend = await User.findById(id);
+  if (!friend) return res.status(404).json({ message: 'Friend not found' });
+  user.friends = user.friends.filter(f => f.toString() !== id);
+  friend.friends = friend.friends.filter(f => f.toString() !== req.user.id);
+  await Promise.all([user.save(), friend.save()]);
+  res.json({ message: 'Friend removed' });
+});
+
 // currency transfer
 apiRouter.post('/transfer', authenticateToken, async (req, res) => {
   const { toUsername, amount, orgId } = req.body;


### PR DESCRIPTION
## Summary
- allow deleting a friend from the API
- document the new `/friends/{id}` endpoint
- mention friend removal in README
- expose `removeFriend` in ApiContext
- add `ManageFriends` page and navigation link
- enable choosing friends on transfer page via Autocomplete (already in place)

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688138cfeef083269c2ec2842fe05d95