### PR TITLE
Fix add member dropdown user list

### DIFF
--- a/frontend/src/pages/ManageUsers.js
+++ b/frontend/src/pages/ManageUsers.js
@@ -25,9 +25,9 @@ export default function ManageUsers() {
     const orgReq = profile?.isSuperAdmin
       ? api.get('/organizations')
       : Promise.resolve({ data: [] });
-    const allReq = currentOrg
-      ? api.get('/users', { params: { orgId: currentOrg } })
-      : api.get('/users');
+    // Always fetch unassigned users so the add member dropdown displays
+    // users that are not already part of any organization
+    const allReq = api.get('/users');
     const [oRes, aRes] = await Promise.all([orgReq, allReq]);
     if (currentOrg) {
       await Promise.all([refreshUsers(currentOrg), refreshRoles(currentOrg)]);


### PR DESCRIPTION
## Summary
- always fetch unassigned users when loading Manage Users

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6881462fc08c83269424c552074b2ea1