### PR TITLE
Add basic social feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ for quick transfers. Retrieve pending requests with `GET /friends/requests`, sen
 a request using `POST /friends/request` and accept with
 `POST /friends/requests/{id}/accept`. A user's friends are listed via `GET /friends`
 and can be removed with `DELETE /friends/{id}`.
+Users may also share updates by creating posts with optional images using
+`POST /posts`. Posts are fetched via `GET /posts` and support reactions with
+`POST /posts/{id}/like`. Comments can be added or viewed through
+`POST /posts/{id}/comments` and `GET /posts/{id}/comments`.
 
 When the server is running you can explore all endpoints using Swagger UI at [`/api-docs`](http://localhost:3000/api-docs).
 
@@ -68,6 +72,7 @@ numbers. Attempts to register or change a password that does not meet this
 policy will result in a `400` response describing the issue.
 
 The frontend runs on port 4000 by default. It includes simple pages for each API endpoint under `src/index.js`, allowing you to register, log in, manage organizations and members, handle invites, transfer currency and update user roles.
+There is also a **Feed** page where users can share posts, like them and leave comments.
 
 All API requests use an Axios instance defined in `src/api.js`. The authentication token is stored using React Context in `src/AuthContext.js`, which automatically adds the `Authorization` header for requests. Login now also returns a long-lived refresh token which the Axios wrapper uses to obtain a new access token when a request returns `401`. Profile updates now support uploading a picture and accepting an invite requires providing the invite's token.
 Profile pictures must be JPEG or PNG images and may not exceed 25MB in size.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -841,3 +841,119 @@ paths:
                   - orgId: org_id
                     orgName: Example Org
                     amount: 100
+
+  /posts:
+    get:
+      summary: List posts
+      responses:
+        '200':
+          description: Posts list
+          content:
+            application/json:
+              example:
+                - id: post_id
+                  content: Hello
+                  image: /uploads/img.jpg
+                  createdAt: 2023-01-01T00:00:00.000Z
+                  author:
+                    id: user_id
+                    username: johndoe
+                    firstName: John
+                    lastName: Doe
+                    profilePicture: /uploads/pic.jpg
+                  likes: 1
+                  liked: true
+    post:
+      summary: Create post
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                content:
+                  type: string
+                image:
+                  type: string
+                  format: binary
+              required:
+                - content
+      responses:
+        '200':
+          description: Post created
+          content:
+            application/json:
+              example:
+                message: Post created
+                id: post_id
+
+  /posts/{id}/like:
+    post:
+      summary: Like or unlike post
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Like status
+          content:
+            application/json:
+              example:
+                liked: true
+                likes: 1
+
+  /posts/{id}/comments:
+    get:
+      summary: List comments
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Comments list
+          content:
+            application/json:
+              example:
+                - id: comment_id
+                  content: Nice
+                  createdAt: 2023-01-01T00:00:00.000Z
+                  author:
+                    id: user_id
+                    username: janedoe
+                    firstName: Jane
+                    lastName: Doe
+                    profilePicture: /uploads/pic.jpg
+    post:
+      summary: Add comment
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                content:
+                  type: string
+              required:
+                - content
+      responses:
+        '200':
+          description: Comment added
+          content:
+            application/json:
+              example:
+                message: Comment added
+                id: comment_id

--- a/frontend/src/ApiContext.js
+++ b/frontend/src/ApiContext.js
@@ -12,6 +12,7 @@ export function ApiProvider({ children }) {
   const [invites, setInvites] = useState([]);
   const [friends, setFriends] = useState([]);
   const [friendRequests, setFriendRequests] = useState([]);
+  const [posts, setPosts] = useState([]);
 
   const refreshBalance = useCallback(async (orgId = currentOrg) => {
     if (!orgId) { setBalance(null); return; }
@@ -73,6 +74,32 @@ export function ApiProvider({ children }) {
     await refreshFriends();
   };
 
+  const refreshPosts = useCallback(async () => {
+    const res = await api.get('/posts');
+    setPosts(res.data);
+  }, []);
+
+  const createPost = async (data) => {
+    await api.post('/posts', data, {
+      headers: { 'Content-Type': 'multipart/form-data' }
+    });
+    await refreshPosts();
+  };
+
+  const likePost = async (id) => {
+    await api.post(`/posts/${id}/like`);
+    await refreshPosts();
+  };
+
+  const addComment = async (postId, content) => {
+    await api.post(`/posts/${postId}/comments`, { content });
+  };
+
+  const getComments = async (postId) => {
+    const res = await api.get(`/posts/${postId}/comments`);
+    return res.data;
+  };
+
   const register = async (form) => {
     await api.post('/register', form);
   };
@@ -120,6 +147,12 @@ export function ApiProvider({ children }) {
       acceptFriendRequest,
       removeFriend,
       getFriendProfile,
+      posts,
+      refreshPosts,
+      createPost,
+      likePost,
+      addComment,
+      getComments,
       register,
       changePassword,
       forgotPassword,

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -34,6 +34,7 @@ import {
   Logout,
   LockReset,
   People,
+  Home,
   Menu as MenuIcon
 } from '@mui/icons-material';
 import { styles } from './styles';
@@ -50,6 +51,7 @@ import ManageFriends from './pages/ManageFriends';
 import FriendProfile from './pages/FriendProfile';
 import Transfer from './pages/Transfer';
 import Balance from './pages/Balance';
+import Feed from './pages/Feed';
 import Administration from './pages/Administration';
 import ResetPassword from './pages/ResetPassword';
 import ForgotPassword from './pages/ForgotPassword';
@@ -70,6 +72,7 @@ export default function App() {
   const { token, currentOrg, setCurrentOrg, profile, orgs, refreshOrgs, isAdmin } = useContext(AuthContext);
 
   const loggedInNav = [
+    { text: 'Feed', path: '/feed', icon: <Home /> },
     { text: 'Profile', path: '/profile', icon: <AccountCircle /> },
     { text: 'Update Profile', path: '/update-profile', icon: <Edit /> },
     { text: 'Change Password', path: '/change-password', icon: <Lock /> },
@@ -189,13 +192,14 @@ export default function App() {
             <Route path="/accept-friend" element={<AcceptFriend />} />
             <Route path="/manage-friends" element={<ManageFriends />} />
             <Route path="/friend/:id" element={<FriendProfile />} />
+            <Route path="/feed" element={<Feed />} />
             <Route path="/transfer" element={<Transfer />} />
             <Route path="/balance" element={<Balance />} />
             <Route path="/admin" element={<Administration />} />
             <Route path="/logout" element={<LogoutPage />} />
             <Route path="/forgot-password" element={<ForgotPassword />} />
             <Route path="/reset-password" element={<ResetPassword />} />
-            <Route path="/" element={token ? <Balance /> : <Login />} />
+            <Route path="/" element={token ? <Feed /> : <Login />} />
             <Route path="*" element={<Navigate to="/" replace />} />
           </Routes>
         </Box>


### PR DESCRIPTION
## Summary
- implement Post and Comment models and routes
- document new endpoints in OpenAPI
- add social feed UI with posts, likes and comments
- extend API context with post helpers
- show Feed page and update README

## Testing
- `npm install`
- `node build.js` in `frontend`
- `node index.js` *(fails: querySrv ENOTFOUND)*

------
https://chatgpt.com/codex/tasks/task_e_688144ba9bb083268662396c0306c559