### PR TITLE
Maintain feed image preview aspect ratio

### DIFF
--- a/frontend/src/pages/Feed.js
+++ b/frontend/src/pages/Feed.js
@@ -121,7 +121,7 @@ export default function Feed() {
             />
           </Button>
           {preview && (
-            <Box component="img" src={preview} sx={{ maxWidth: '100%', maxHeight: 400 }} />
+            <Box component="img" src={preview} sx={{ maxWidth: '100%' }} />
           )}
           <Button type="submit" variant="contained">Post</Button>
         </Stack>


### PR DESCRIPTION
## Summary
- keep the aspect ratio when previewing an uploaded image in the feed by just setting `maxWidth: '100%'`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688155f09c508326bd568df112df0a47