### PR TITLE
Apply swagger style to feed

### DIFF
--- a/frontend/src/pages/Feed.js
+++ b/frontend/src/pages/Feed.js
@@ -128,7 +128,7 @@ export default function Feed() {
       </Box>
       <Stack spacing={2} sx={{ mt: 4 }}>
         {posts.map(p => (
-          <Box key={p.id} sx={{ border: '1px solid', borderColor: 'divider', borderRadius: 1, p: 2, backgroundColor: 'background.paper' }}>
+          <Box key={p.id} sx={styles.swaggerPost}>
             <Stack direction="row" spacing={2} alignItems="center">
               {p.author.profilePicture && (
                 <Avatar src={p.author.profilePicture.startsWith('http') ? p.author.profilePicture : `${API_ROOT}${p.author.profilePicture}`} />
@@ -150,16 +150,7 @@ export default function Feed() {
             {comments[p.id] && (
               <Box sx={{ mt: 1 }}>
                 {comments[p.id].map(c => (
-                  <Box
-                    key={c.id}
-                    sx={{
-                      mt: 1,
-                      ml: 2,
-                      p: 1,
-                      borderRadius: 1,
-                      backgroundColor: 'grey.50'
-                    }}
-                  >
+                  <Box key={c.id} sx={styles.swaggerComment}>
                     <Stack direction="row" spacing={1} alignItems="flex-start">
                       {c.author.profilePicture && (
                         <Avatar

--- a/frontend/src/styles.js
+++ b/frontend/src/styles.js
@@ -90,5 +90,21 @@ export const styles = {
   adminContent: { mt: 2 },
   ml1: { ml: 1 },
   mb2: { mb: 2 },
-  mt2: { mt: 2 }
+  mt2: { mt: 2 },
+  swaggerPost: {
+    border: '1px solid #e8e8e8',
+    borderLeft: '5px solid #61affe',
+    borderRadius: 2,
+    backgroundColor: '#f7f7f7',
+    p: 2
+  },
+  swaggerComment: {
+    mt: 1,
+    ml: 2,
+    p: 1,
+    borderRadius: 1,
+    backgroundColor: '#fff',
+    border: '1px solid #e8e8e8',
+    borderLeft: '5px solid #49cc90'
+  }
 };


### PR DESCRIPTION
## Summary
- add swagger-inspired styling helpers
- style feed posts and comments with Swagger color scheme

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688158f3b71c8326a5cdc241486b6a4e