### PR TITLE
Fix feed to filter posts by friends

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,10 @@ a request using `POST /friends/request` and accept with
 `POST /friends/requests/{id}/accept`. A user's friends are listed via `GET /friends`
 and can be removed with `DELETE /friends/{id}`.
 Users may also share updates by creating posts with optional images using
-`POST /posts`. Posts are fetched via `GET /posts` and support reactions with
-`POST /posts/{id}/like`. Comments can be added or viewed through
-`POST /posts/{id}/comments` and `GET /posts/{id}/comments`.
+`POST /posts`. Posts are fetched via `GET /posts`, which returns posts from you
+and your friends, and support reactions with `POST /posts/{id}/like`.
+Comments can be added or viewed through `POST /posts/{id}/comments` and
+`GET /posts/{id}/comments`.
 
 When the server is running you can explore all endpoints using Swagger UI at [`/api-docs`](http://localhost:3000/api-docs).
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -845,6 +845,7 @@ paths:
   /posts:
     get:
       summary: List posts
+      description: Return recent posts from you and your friends
       responses:
         '200':
           description: Posts list

--- a/index.js
+++ b/index.js
@@ -992,7 +992,9 @@ apiRouter.post('/posts', authenticateToken, (req, res) => {
 });
 
 apiRouter.get('/posts', authenticateToken, async (req, res) => {
-  const posts = await Post.find()
+  const user = await User.findById(req.user.id);
+  const ids = [req.user.id, ...user.friends];
+  const posts = await Post.find({ author: { $in: ids } })
     .sort({ createdAt: -1 })
     .populate('author', 'username firstName lastName profilePicture');
   res.json(


### PR DESCRIPTION
## Summary
- show only posts from the current user and their friends
- document feed filtering in API docs and README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68815a2a91cc8326aac55b02981882dd