### PR TITLE
Add group feed system

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ policy will result in a `400` response describing the issue.
 
 The frontend runs on port 4000 by default. It includes simple pages for each API endpoint under `src/index.js`, allowing you to register, log in, manage organizations and members, handle invites, transfer currency and update user roles.
 There is also a **Feed** page where users can share posts, like them and leave comments.
+Selecting an organization from the dropdown adds an **Organization Feed** page that displays posts created within that group.
 
 All API requests use an Axios instance defined in `src/api.js`. The authentication token is stored using React Context in `src/AuthContext.js`, which automatically adds the `Authorization` header for requests. Login now also returns a long-lived refresh token which the Axios wrapper uses to obtain a new access token when a request returns `401`. Profile updates now support uploading a picture and accepting an invite requires providing the invite's token.
 Profile pictures must be JPEG or PNG images and may not exceed 25MB in size.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -889,6 +889,64 @@ paths:
                 message: Post created
                 id: post_id
 
+  /organizations/{id}/posts:
+    get:
+      summary: List organization posts
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Posts list
+          content:
+            application/json:
+              example:
+                - id: post_id
+                  content: Hello
+                  image: /uploads/img.jpg
+                  createdAt: 2023-01-01T00:00:00.000Z
+                  author:
+                    id: user_id
+                    username: johndoe
+                    firstName: John
+                    lastName: Doe
+                    profilePicture: /uploads/pic.jpg
+                  likes: 1
+                  liked: true
+    post:
+      summary: Create organization post
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                content:
+                  type: string
+                image:
+                  type: string
+                  format: binary
+              required:
+                - content
+      responses:
+        '200':
+          description: Post created
+          content:
+            application/json:
+              example:
+                message: Post created
+                id: post_id
+
   /posts/{id}/like:
     post:
       summary: Like or unlike post

--- a/frontend/src/ApiContext.js
+++ b/frontend/src/ApiContext.js
@@ -13,6 +13,7 @@ export function ApiProvider({ children }) {
   const [friends, setFriends] = useState([]);
   const [friendRequests, setFriendRequests] = useState([]);
   const [posts, setPosts] = useState([]);
+  const [orgPosts, setOrgPosts] = useState([]);
 
   const refreshBalance = useCallback(async (orgId = currentOrg) => {
     if (!orgId) { setBalance(null); return; }
@@ -79,11 +80,25 @@ export function ApiProvider({ children }) {
     setPosts(res.data);
   }, []);
 
+  const refreshOrgPosts = useCallback(async (orgId = currentOrg) => {
+    if (!orgId) { setOrgPosts([]); return; }
+    const res = await api.get(`/organizations/${orgId}/posts`);
+    setOrgPosts(res.data);
+  }, [currentOrg]);
+
   const createPost = async (data) => {
     await api.post('/posts', data, {
       headers: { 'Content-Type': 'multipart/form-data' }
     });
     await refreshPosts();
+  };
+
+  const createOrgPost = async (data, orgId = currentOrg) => {
+    if (!orgId) return;
+    await api.post(`/organizations/${orgId}/posts`, data, {
+      headers: { 'Content-Type': 'multipart/form-data' }
+    });
+    await refreshOrgPosts(orgId);
   };
 
   const likePost = async (id) => {
@@ -150,6 +165,9 @@ export function ApiProvider({ children }) {
       posts,
       refreshPosts,
       createPost,
+      orgPosts,
+      refreshOrgPosts,
+      createOrgPost,
       likePost,
       addComment,
       getComments,

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -52,6 +52,7 @@ import FriendProfile from './pages/FriendProfile';
 import Transfer from './pages/Transfer';
 import Balance from './pages/Balance';
 import Feed from './pages/Feed';
+import OrganizationFeed from './pages/OrganizationFeed';
 import Administration from './pages/Administration';
 import ResetPassword from './pages/ResetPassword';
 import ForgotPassword from './pages/ForgotPassword';
@@ -81,6 +82,7 @@ export default function App() {
     { text: 'Friend Requests', path: '/accept-friend', icon: <HowToReg /> },
     { text: 'Friends', path: '/manage-friends', icon: <People /> },
     ...(currentOrg ? [
+      { text: 'Organization Feed', path: '/org-feed', icon: <Home /> },
       { text: 'Transfer', path: '/transfer', icon: <SwapHoriz /> },
       { text: 'Balance', path: '/balance', icon: <AccountBalanceWallet /> }
     ] : []),
@@ -193,6 +195,7 @@ export default function App() {
             <Route path="/manage-friends" element={<ManageFriends />} />
             <Route path="/friend/:id" element={<FriendProfile />} />
             <Route path="/feed" element={<Feed />} />
+            <Route path="/org-feed" element={<OrganizationFeed />} />
             <Route path="/transfer" element={<Transfer />} />
             <Route path="/balance" element={<Balance />} />
             <Route path="/admin" element={<Administration />} />

--- a/frontend/src/pages/OrganizationFeed.js
+++ b/frontend/src/pages/OrganizationFeed.js
@@ -1,0 +1,197 @@
+import React, { useEffect, useState, useContext } from 'react';
+import {
+  Box,
+  Stack,
+  TextField,
+  Button,
+  Avatar,
+  Typography,
+  IconButton
+} from '@mui/material';
+import FavoriteIcon from '@mui/icons-material/Favorite';
+import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
+import { ApiContext } from '../ApiContext';
+import { ToastContext } from '../ToastContext';
+import { API_ROOT } from '../api';
+import { styles } from '../styles';
+
+export default function OrganizationFeed() {
+  const {
+    orgPosts,
+    refreshOrgPosts,
+    createOrgPost,
+    likePost,
+    getComments,
+    addComment
+  } = useContext(ApiContext);
+  const { showToast } = useContext(ToastContext);
+  const [content, setContent] = useState('');
+  const [image, setImage] = useState(null);
+  const [preview, setPreview] = useState('');
+  const [comments, setComments] = useState({});
+  const [commentInput, setCommentInput] = useState({});
+
+  useEffect(() => {
+    refreshOrgPosts();
+  }, [refreshOrgPosts]);
+
+  const submit = async e => {
+    e.preventDefault();
+    if (!content.trim() && !image) {
+      showToast('Post content required', 'error');
+      return;
+    }
+    const data = new FormData();
+    data.append('content', content.trim());
+    if (image) data.append('image', image);
+    try {
+      await createOrgPost(data);
+      showToast('Post created', 'success');
+      setContent('');
+      setImage(null);
+      setPreview('');
+    } catch (err) {
+      showToast(err.response?.data?.message || 'Error creating post', 'error');
+    }
+  };
+
+  const toggleLike = async id => {
+    try {
+      await likePost(id);
+    } catch (err) {
+      showToast(err.response?.data?.message || 'Error', 'error');
+    }
+  };
+
+  const loadComments = async id => {
+    if (comments[id]) {
+      setComments(prev => ({ ...prev, [id]: null }));
+      return;
+    }
+    try {
+      const res = await getComments(id);
+      setComments(prev => ({ ...prev, [id]: res }));
+    } catch (err) {
+      showToast('Failed to load comments', 'error');
+    }
+  };
+
+  const submitComment = async (e, id) => {
+    e.preventDefault();
+    const text = commentInput[id]?.trim();
+    if (!text) return;
+    try {
+      await addComment(id, text);
+      const res = await getComments(id);
+      setComments(prev => ({ ...prev, [id]: res }));
+      setCommentInput(prev => ({ ...prev, [id]: '' }));
+    } catch (err) {
+      showToast(err.response?.data?.message || 'Error', 'error');
+    }
+  };
+
+  return (
+    <Box>
+      <Box component="form" onSubmit={submit} noValidate>
+        <Stack spacing={2} sx={styles.formStack}>
+          <TextField
+            label="What's on your mind?"
+            multiline
+            rows={3}
+            value={content}
+            onChange={e => setContent(e.target.value)}
+          />
+          <Button variant="contained" component="label">
+            Upload Image
+            <input
+              hidden
+              type="file"
+              accept="image/*"
+              onChange={e => {
+                const f = e.target.files[0];
+                setImage(f);
+                if (f) {
+                  const reader = new FileReader();
+                  reader.onload = ev => setPreview(ev.target.result);
+                  reader.readAsDataURL(f);
+                } else {
+                  setPreview('');
+                }
+              }}
+            />
+          </Button>
+          {preview && (
+            <Box component="img" src={preview} sx={{ maxWidth: '100%' }} />
+          )}
+          <Button type="submit" variant="contained">Post</Button>
+        </Stack>
+      </Box>
+      <Stack spacing={2} sx={{ mt: 4 }}>
+        {orgPosts.map(p => (
+          <Box key={p.id} sx={styles.swaggerPost}>
+            <Stack direction="row" spacing={2} alignItems="center">
+              {p.author.profilePicture && (
+                <Avatar src={p.author.profilePicture.startsWith('http') ? p.author.profilePicture : `${API_ROOT}${p.author.profilePicture}`} />
+              )}
+              <Typography variant="subtitle1">{p.author.firstName} {p.author.lastName}</Typography>
+              <Typography variant="caption" sx={{ ml: 'auto' }}>{new Date(p.createdAt).toLocaleString()}</Typography>
+            </Stack>
+            <Typography sx={{ mt: 1, mb: 1 }}>{p.content}</Typography>
+            {p.image && (
+              <Box component="img" src={p.image.startsWith('http') ? p.image : `${API_ROOT}${p.image}`} sx={{ maxWidth: '100%', maxHeight: 400 }} />
+            )}
+            <Stack direction="row" alignItems="center" spacing={1} sx={{ mt: 1 }}>
+              <IconButton onClick={() => toggleLike(p.id)} color="error">
+                {p.liked ? <FavoriteIcon /> : <FavoriteBorderIcon />}
+              </IconButton>
+              <Typography>{p.likes}</Typography>
+              <Button onClick={() => loadComments(p.id)}>Comments</Button>
+            </Stack>
+            {comments[p.id] && (
+              <Box sx={{ mt: 1 }}>
+                {comments[p.id].map(c => (
+                  <Box key={c.id} sx={styles.swaggerComment}>
+                    <Stack direction="row" spacing={1} alignItems="flex-start">
+                      {c.author.profilePicture && (
+                        <Avatar
+                          src={c.author.profilePicture.startsWith('http') ? c.author.profilePicture : `${API_ROOT}${c.author.profilePicture}`}
+                          sx={{ width: 24, height: 24, mt: 0.5 }}
+                        />
+                      )}
+                      <Box sx={{ flexGrow: 1 }}>
+                        <Stack direction="row" spacing={1} alignItems="center">
+                          <Typography variant="subtitle2">
+                            {c.author.firstName} {c.author.lastName}
+                          </Typography>
+                          <Typography variant="caption" sx={{ ml: 'auto' }}>
+                            {new Date(c.createdAt).toLocaleString()}
+                          </Typography>
+                        </Stack>
+                        <Typography sx={{ mt: 0.5 }}>{c.content}</Typography>
+                      </Box>
+                    </Stack>
+                  </Box>
+                ))}
+                <Box component="form" onSubmit={e => submitComment(e, p.id)} sx={{ mt: 1, ml: 2 }}>
+                  <Stack direction="row" spacing={1}>
+                    <TextField
+                      variant="standard"
+                      size="small"
+                      fullWidth
+                      placeholder="Add a comment"
+                      value={commentInput[p.id] || ''}
+                      onChange={e =>
+                        setCommentInput(prev => ({ ...prev, [p.id]: e.target.value }))
+                      }
+                    />
+                    <Button type="submit">Send</Button>
+                  </Stack>
+                </Box>
+              </Box>
+            )}
+          </Box>
+        ))}
+      </Stack>
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary
- document Organization Feed in README
- support creating posts under organizations in API
- document new endpoints in OpenAPI spec
- expose organization posts via ApiContext and new OrganizationFeed page
- add Organization Feed link and route in frontend

## Testing
- `node -c index.js`
- `node -c frontend/src/ApiContext.js`


------
https://chatgpt.com/codex/tasks/task_e_68815ea9d6b4832682224e8727f384d4