### PR TITLE
Fix org feed like refresh

### DIFF
--- a/frontend/src/ApiContext.js
+++ b/frontend/src/ApiContext.js
@@ -106,6 +106,11 @@ export function ApiProvider({ children }) {
     await refreshPosts();
   };
 
+  const likeOrgPost = async (id, orgId = currentOrg) => {
+    await api.post(`/posts/${id}/like`);
+    await refreshOrgPosts(orgId);
+  };
+
   const addComment = async (postId, content) => {
     await api.post(`/posts/${postId}/comments`, { content });
   };
@@ -169,6 +174,7 @@ export function ApiProvider({ children }) {
       refreshOrgPosts,
       createOrgPost,
       likePost,
+      likeOrgPost,
       addComment,
       getComments,
       register,

--- a/frontend/src/pages/OrganizationFeed.js
+++ b/frontend/src/pages/OrganizationFeed.js
@@ -20,7 +20,7 @@ export default function OrganizationFeed() {
     orgPosts,
     refreshOrgPosts,
     createOrgPost,
-    likePost,
+    likeOrgPost,
     getComments,
     addComment
   } = useContext(ApiContext);
@@ -57,7 +57,7 @@ export default function OrganizationFeed() {
 
   const toggleLike = async id => {
     try {
-      await likePost(id);
+      await likeOrgPost(id);
     } catch (err) {
       showToast(err.response?.data?.message || 'Error', 'error');
     }


### PR DESCRIPTION
## Summary
- add `likeOrgPost` helper to `ApiContext`
- use `likeOrgPost` inside organization feed to keep likes up to date

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6881618d788083268e41eccfe0c185c5