### PR TITLE
Prevent self-crediting posts or comments

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1012,6 +1012,7 @@ paths:
   /posts/{id}/credit:
     post:
       summary: Give credit to a post
+      description: Cannot be used on your own posts
       parameters:
         - in: path
           name: id
@@ -1133,6 +1134,7 @@ paths:
   /comments/{id}/credit:
     post:
       summary: Give credit to a comment
+      description: Cannot be used on your own comments
       parameters:
         - in: path
           name: id

--- a/index.js
+++ b/index.js
@@ -1187,6 +1187,9 @@ apiRouter.post('/posts/:id/credit', authenticateToken, async (req, res) => {
   }
   const post = await Post.findById(id);
   if (!post) return res.status(404).json({ message: 'Post not found' });
+  if (post.author.toString() === req.user.id) {
+    return res.status(400).json({ message: 'Cannot credit own post' });
+  }
   const useOrg = post.organization || orgId;
   if (!useOrg) return res.status(400).json({ message: 'Organization required' });
   const user = await User.findById(req.user.id);
@@ -1300,6 +1303,9 @@ apiRouter.post('/comments/:id/credit', authenticateToken, async (req, res) => {
     return res.status(400).json({ message: 'Invalid amount' });
   const comment = await Comment.findById(id).populate('post');
   if (!comment) return res.status(404).json({ message: 'Comment not found' });
+  if (comment.author.toString() === req.user.id) {
+    return res.status(400).json({ message: 'Cannot credit own comment' });
+  }
   const useOrg = comment.post.organization || orgId;
   if (!useOrg)
     return res.status(400).json({ message: 'Organization required' });


### PR DESCRIPTION
## Summary
- block users from crediting their own posts or comments
- document the restriction in the API docs

## Testing
- `node -c index.js`


------
https://chatgpt.com/codex/tasks/task_e_688165c4e3d483269de55cc1eed6c625