### PR TITLE
Add credit transfer to author

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1012,7 +1012,7 @@ paths:
   /posts/{id}/credit:
     post:
       summary: Give credit to a post
-      description: Cannot be used on your own posts
+      description: Cannot be used on your own posts. Transfers the credited amount to the author's balance.
       parameters:
         - in: path
           name: id
@@ -1034,7 +1034,7 @@ paths:
                 - amount
       responses:
         '200':
-          description: Updated credits
+          description: Updated credits and balance of the user who gave credit
           content:
             application/json:
               example:
@@ -1134,7 +1134,7 @@ paths:
   /comments/{id}/credit:
     post:
       summary: Give credit to a comment
-      description: Cannot be used on your own comments
+      description: Cannot be used on your own comments. Transfers the credited amount to the author's balance.
       parameters:
         - in: path
           name: id
@@ -1156,7 +1156,7 @@ paths:
                 - amount
       responses:
         '200':
-          description: Updated credits
+          description: Updated credits and balance of the user who gave credit
           content:
             application/json:
               example:

--- a/index.js
+++ b/index.js
@@ -1196,9 +1196,18 @@ apiRouter.post('/posts/:id/credit', authenticateToken, async (req, res) => {
   const bal = user.balances.find(b => b.orgId.toString() === useOrg.toString());
   if (!bal || bal.amount < num)
     return res.status(400).json({ message: 'Insufficient balance' });
+  const author = await User.findById(post.author);
+  let authorBal = author.balances.find(
+    b => b.orgId.toString() === useOrg.toString()
+  );
+  if (authorBal) {
+    authorBal.amount += num;
+  } else {
+    author.balances.push({ orgId: useOrg, amount: num });
+  }
   bal.amount -= num;
   post.credits += num;
-  await Promise.all([user.save(), post.save()]);
+  await Promise.all([user.save(), author.save(), post.save()]);
   res.json({ credits: post.credits, balance: bal.amount });
 });
 
@@ -1313,9 +1322,18 @@ apiRouter.post('/comments/:id/credit', authenticateToken, async (req, res) => {
   const bal = user.balances.find(b => b.orgId.toString() === useOrg.toString());
   if (!bal || bal.amount < num)
     return res.status(400).json({ message: 'Insufficient balance' });
+  const author = await User.findById(comment.author);
+  let authorBal = author.balances.find(
+    b => b.orgId.toString() === useOrg.toString()
+  );
+  if (authorBal) {
+    authorBal.amount += num;
+  } else {
+    author.balances.push({ orgId: useOrg, amount: num });
+  }
   bal.amount -= num;
   comment.credits += num;
-  await Promise.all([user.save(), comment.save()]);
+  await Promise.all([user.save(), author.save(), comment.save()]);
   res.json({ credits: comment.credits, balance: bal.amount });
 });
 


### PR DESCRIPTION
## Summary
- transfer credits to the author's balance when crediting posts or comments
- document that crediting a post or comment deposits the amount to the author

## Testing
- `no tests`

------
https://chatgpt.com/codex/tasks/task_e_688166b9c9f483268b7ae2884570a476