### PR TITLE
Enable variable credit amounts

### DIFF
--- a/frontend/src/pages/Feed.js
+++ b/frontend/src/pages/Feed.js
@@ -39,6 +39,8 @@ export default function Feed() {
   const [preview, setPreview] = useState('');
   const [comments, setComments] = useState({});
   const [commentInput, setCommentInput] = useState({});
+  const [postCreditInput, setPostCreditInput] = useState({});
+  const [commentCreditInput, setCommentCreditInput] = useState({});
 
   useEffect(() => {
     refreshPosts();
@@ -89,14 +91,14 @@ export default function Feed() {
   };
 
   const handleCreditPost = async id => {
-    const amountStr = window.prompt('Amount to credit?');
-    const amount = parseFloat(amountStr);
-    if (!amountStr || isNaN(amount) || amount <= 0) {
+    const amount = parseFloat(postCreditInput[id]);
+    if (!postCreditInput[id] || isNaN(amount) || amount <= 0) {
       showToast('Invalid amount', 'error');
       return;
     }
     try {
       await creditPost(id, amount);
+      setPostCreditInput(prev => ({ ...prev, [id]: '' }));
     } catch (err) {
       showToast(err.response?.data?.message || 'Error', 'error');
     }
@@ -150,9 +152,8 @@ export default function Feed() {
   };
 
   const handleCreditComment = async (id, postId) => {
-    const amountStr = window.prompt('Amount to credit?');
-    const amount = parseFloat(amountStr);
-    if (!amountStr || isNaN(amount) || amount <= 0) {
+    const amount = parseFloat(commentCreditInput[id]);
+    if (!commentCreditInput[id] || isNaN(amount) || amount <= 0) {
       showToast('Invalid amount', 'error');
       return;
     }
@@ -160,6 +161,7 @@ export default function Feed() {
       await creditComment(id, amount);
       const res = await getComments(postId);
       setComments(prev => ({ ...prev, [postId]: res }));
+      setCommentCreditInput(prev => ({ ...prev, [id]: '' }));
     } catch (err) {
       showToast(err.response?.data?.message || 'Error', 'error');
     }
@@ -228,6 +230,16 @@ export default function Feed() {
                 <ThumbDownIcon fontSize="small" />
               </IconButton>
               <Typography>{p.downvotes}</Typography>
+              <TextField
+                variant="standard"
+                size="small"
+                value={postCreditInput[p.id] || ''}
+                onChange={e =>
+                  setPostCreditInput(prev => ({ ...prev, [p.id]: e.target.value }))
+                }
+                placeholder="Amount"
+                sx={{ width: 60 }}
+              />
               <IconButton onClick={() => handleCreditPost(p.id)}>
                 <AttachMoneyIcon fontSize="small" />
               </IconButton>
@@ -264,6 +276,19 @@ export default function Feed() {
                             <ThumbDownIcon fontSize="small" />
                           </IconButton>
                           <Typography>{c.downvotes}</Typography>
+                          <TextField
+                            variant="standard"
+                            size="small"
+                            value={commentCreditInput[c.id] || ''}
+                            onChange={e =>
+                              setCommentCreditInput(prev => ({
+                                ...prev,
+                                [c.id]: e.target.value
+                              }))
+                            }
+                            placeholder="Amount"
+                            sx={{ width: 60 }}
+                          />
                           <IconButton onClick={() => handleCreditComment(c.id, p.id)}>
                             <AttachMoneyIcon fontSize="small" />
                           </IconButton>

--- a/frontend/src/pages/Feed.js
+++ b/frontend/src/pages/Feed.js
@@ -89,8 +89,14 @@ export default function Feed() {
   };
 
   const handleCreditPost = async id => {
+    const amountStr = window.prompt('Amount to credit?');
+    const amount = parseFloat(amountStr);
+    if (!amountStr || isNaN(amount) || amount <= 0) {
+      showToast('Invalid amount', 'error');
+      return;
+    }
     try {
-      await creditPost(id, 1);
+      await creditPost(id, amount);
     } catch (err) {
       showToast(err.response?.data?.message || 'Error', 'error');
     }
@@ -144,8 +150,14 @@ export default function Feed() {
   };
 
   const handleCreditComment = async (id, postId) => {
+    const amountStr = window.prompt('Amount to credit?');
+    const amount = parseFloat(amountStr);
+    if (!amountStr || isNaN(amount) || amount <= 0) {
+      showToast('Invalid amount', 'error');
+      return;
+    }
     try {
-      await creditComment(id, 1);
+      await creditComment(id, amount);
       const res = await getComments(postId);
       setComments(prev => ({ ...prev, [postId]: res }));
     } catch (err) {

--- a/frontend/src/pages/OrganizationFeed.js
+++ b/frontend/src/pages/OrganizationFeed.js
@@ -94,8 +94,14 @@ export default function OrganizationFeed() {
   };
 
   const handleCreditPost = async id => {
+    const amountStr = window.prompt('Amount to credit?');
+    const amount = parseFloat(amountStr);
+    if (!amountStr || isNaN(amount) || amount <= 0) {
+      showToast('Invalid amount', 'error');
+      return;
+    }
     try {
-      await creditPost(id, 1, currentOrg);
+      await creditPost(id, amount, currentOrg);
     } catch (err) {
       showToast(err.response?.data?.message || 'Error', 'error');
     }
@@ -149,8 +155,14 @@ export default function OrganizationFeed() {
   };
 
   const handleCreditComment = async (id, postId) => {
+    const amountStr = window.prompt('Amount to credit?');
+    const amount = parseFloat(amountStr);
+    if (!amountStr || isNaN(amount) || amount <= 0) {
+      showToast('Invalid amount', 'error');
+      return;
+    }
     try {
-      await creditComment(id, 1, currentOrg);
+      await creditComment(id, amount, currentOrg);
       const res = await getComments(postId);
       setComments(prev => ({ ...prev, [postId]: res }));
     } catch (err) {

--- a/frontend/src/pages/OrganizationFeed.js
+++ b/frontend/src/pages/OrganizationFeed.js
@@ -43,6 +43,8 @@ export default function OrganizationFeed() {
   const [preview, setPreview] = useState('');
   const [comments, setComments] = useState({});
   const [commentInput, setCommentInput] = useState({});
+  const [postCreditInput, setPostCreditInput] = useState({});
+  const [commentCreditInput, setCommentCreditInput] = useState({});
 
   useEffect(() => {
     refreshOrgPosts();
@@ -94,14 +96,14 @@ export default function OrganizationFeed() {
   };
 
   const handleCreditPost = async id => {
-    const amountStr = window.prompt('Amount to credit?');
-    const amount = parseFloat(amountStr);
-    if (!amountStr || isNaN(amount) || amount <= 0) {
+    const amount = parseFloat(postCreditInput[id]);
+    if (!postCreditInput[id] || isNaN(amount) || amount <= 0) {
       showToast('Invalid amount', 'error');
       return;
     }
     try {
       await creditPost(id, amount, currentOrg);
+      setPostCreditInput(prev => ({ ...prev, [id]: '' }));
     } catch (err) {
       showToast(err.response?.data?.message || 'Error', 'error');
     }
@@ -155,9 +157,8 @@ export default function OrganizationFeed() {
   };
 
   const handleCreditComment = async (id, postId) => {
-    const amountStr = window.prompt('Amount to credit?');
-    const amount = parseFloat(amountStr);
-    if (!amountStr || isNaN(amount) || amount <= 0) {
+    const amount = parseFloat(commentCreditInput[id]);
+    if (!commentCreditInput[id] || isNaN(amount) || amount <= 0) {
       showToast('Invalid amount', 'error');
       return;
     }
@@ -165,6 +166,7 @@ export default function OrganizationFeed() {
       await creditComment(id, amount, currentOrg);
       const res = await getComments(postId);
       setComments(prev => ({ ...prev, [postId]: res }));
+      setCommentCreditInput(prev => ({ ...prev, [id]: '' }));
     } catch (err) {
       showToast(err.response?.data?.message || 'Error', 'error');
     }
@@ -238,6 +240,16 @@ export default function OrganizationFeed() {
                 <ThumbDownIcon fontSize="small" />
               </IconButton>
               <Typography>{p.downvotes}</Typography>
+              <TextField
+                variant="standard"
+                size="small"
+                value={postCreditInput[p.id] || ''}
+                onChange={e =>
+                  setPostCreditInput(prev => ({ ...prev, [p.id]: e.target.value }))
+                }
+                placeholder="Amount"
+                sx={{ width: 60 }}
+              />
               <IconButton onClick={() => handleCreditPost(p.id)}>
                 <AttachMoneyIcon fontSize="small" />
               </IconButton>
@@ -274,6 +286,19 @@ export default function OrganizationFeed() {
                             <ThumbDownIcon fontSize="small" />
                           </IconButton>
                           <Typography>{c.downvotes}</Typography>
+                          <TextField
+                            variant="standard"
+                            size="small"
+                            value={commentCreditInput[c.id] || ''}
+                            onChange={e =>
+                              setCommentCreditInput(prev => ({
+                                ...prev,
+                                [c.id]: e.target.value
+                              }))
+                            }
+                            placeholder="Amount"
+                            sx={{ width: 60 }}
+                          />
                           <IconButton onClick={() => handleCreditComment(c.id, p.id)}>
                             <AttachMoneyIcon fontSize="small" />
                           </IconButton>


### PR DESCRIPTION
## Summary
- allow entering custom credit amount for posts and comments

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68826a303198832698e7cbc5445ffc51