### PR TITLE
Fix mismatched closing tag in OrganizationFeed

### DIFF
--- a/frontend/src/pages/OrganizationFeed.js
+++ b/frontend/src/pages/OrganizationFeed.js
@@ -424,7 +424,6 @@ export default function OrganizationFeed() {
                           </Box>
                         )}
                       </Box>
-                      </Box>
                     </Stack>
                   </Box>
                 ))}


### PR DESCRIPTION
## Summary
- remove extraneous `</Box>` that caused an unmatched closing tag in `OrganizationFeed.js`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68827815c74c8326a30b9f93e2fc7aa8