### PR TITLE
Fix organization admin manage users

### DIFF
--- a/frontend/src/pages/ManageUsers.js
+++ b/frontend/src/pages/ManageUsers.js
@@ -25,9 +25,11 @@ export default function ManageUsers() {
     const orgReq = profile?.isSuperAdmin
       ? api.get('/organizations')
       : Promise.resolve({ data: [] });
-    // Always fetch unassigned users so the add member dropdown displays
-    // users that are not already part of any organization
-    const allReq = api.get('/users');
+    // Only super admins may add members so fetch unassigned users
+    // for them. Organization admins don't need this list.
+    const allReq = profile?.isSuperAdmin
+      ? api.get('/users')
+      : Promise.resolve({ data: [] });
     const [oRes, aRes] = await Promise.all([orgReq, allReq]);
     if (currentOrg) {
       await Promise.all([refreshUsers(currentOrg), refreshRoles(currentOrg)]);


### PR DESCRIPTION
## Summary
- only fetch unassigned users when logged in as super admin so org admins don't hit `/users`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6882903ed8bc83269df544a53958de6d